### PR TITLE
State machine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,9 +176,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbc37d37da9e5bce8173f3a41b71d9bf3c674deebbaceacd0ebdabde76efb03"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.0"
+version = "4.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
+checksum = "ca8f255e4b8027970e78db75e78831229c9815fdbfa67eb1a1b777a62e24b4a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.0"
+version = "4.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
+checksum = "acd4f3c17c83b0ba34ffbc4f8bbd74f079413f747f84a6f89292f138057e36ab"
 dependencies = [
  "anstream",
  "anstyle",
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.0"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -374,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.3.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7394a21d012ce5c850497fb774b167d81b99f060025fbf06ee92b9848bd97eb2"
+checksum = "2a011bbe2c35ce9c1f143b7af6f94f29a167beb4cd1d29e6740ce836f723120e"
 dependencies = [
  "nix 0.26.2",
  "windows-sys 0.48.0",
@@ -807,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "mach"
@@ -1233,9 +1233,9 @@ checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "ringbuffer"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e4fbb37fd18bd949f42583141d650fcdce49dbf759264e4dd3a5df0bc15dc6"
+checksum = "2f4d2457fd775198df9ec68fef08ed8038cfb6f532c552d2946036a2432b7b81"
 
 [[package]]
 name = "rustix"
@@ -1274,18 +1274,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.3"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8f255e4b8027970e78db75e78831229c9815fdbfa67eb1a1b777a62e24b4a0"
+checksum = "80672091db20273a15cf9fdd4e47ed43b5091ec9841bf4c6145c9dfbbcae09ed"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.3"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd4f3c17c83b0ba34ffbc4f8bbd74f079413f747f84a6f89292f138057e36ab"
+checksum = "c1458a1df40e1e2afebb7ab60ce55c1fa8f431146205aa5f4887e0b111c27636"
 dependencies = [
  "anstream",
  "anstyle",
@@ -765,9 +765,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libudev"
@@ -985,9 +985,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "parking_lot"
@@ -1090,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,12 +25,18 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -92,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "approx"
@@ -125,18 +131,18 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "bytemuck"
@@ -170,13 +176,13 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "fdbc37d37da9e5bce8173f3a41b71d9bf3c674deebbaceacd0ebdabde76efb03"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
  "serde",
  "time 0.1.45",
@@ -217,7 +223,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -227,16 +233,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,15 +240,15 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]
@@ -297,6 +293,7 @@ dependencies = [
  "log",
  "nalgebra",
  "ringbuffer",
+ "serde",
 ]
 
 [[package]]
@@ -386,50 +383,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cxx"
-version = "1.0.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "darling"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,7 +403,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -461,7 +414,7 @@ checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -472,9 +425,9 @@ checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -589,7 +542,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -621,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -631,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -700,26 +653,25 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.53"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "winapi",
+ "windows",
 ]
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cc",
 ]
 
 [[package]]
@@ -760,25 +712,25 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256017f749ab3117e93acb91063009e1f1bb56d03965b14c2c8df4eb02c524d8"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -798,9 +750,9 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -813,9 +765,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libudev"
@@ -838,19 +790,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "linux-raw-sys"
-version = "0.3.1"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
@@ -888,10 +831,11 @@ dependencies = [
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.2"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
+checksum = "090126dc04f95dc0d1c1c91f61bdd474b3930ca064c1edc8a849da2c6cbe1e77"
 dependencies = [
+ "autocfg",
  "rawpointer",
 ]
 
@@ -912,14 +856,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "eebffdb73fe72e917997fad08bdbf31ac50b0fa91cec93e69a0662e4264d454c"
 dependencies = [
  "libc",
- "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1042,9 +985,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
 
 [[package]]
 name = "parking_lot"
@@ -1064,16 +1007,16 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "percent-encoding"
@@ -1093,22 +1036,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1125,9 +1068,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "ppv-lite86"
@@ -1137,9 +1080,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.1.23"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e3215779627f01ee256d2fad52f3d95e8e1c11e9fc6fd08f7cd455d5d5c78"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
  "proc-macro2",
  "syn 1.0.109",
@@ -1147,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
  "unicode-ident",
 ]
@@ -1166,9 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.6"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f8ad728fb08fe212df3c05169e940fbb6d9d16a877ddde14644a983ba2012e"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck",
@@ -1210,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -1263,10 +1206,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.7.1"
+name = "redox_syscall"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1275,18 +1227,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "ringbuffer"
@@ -1296,16 +1239,16 @@ checksum = "b6e4fbb37fd18bd949f42583141d650fcdce49dbf759264e4dd3a5df0bc15dc6"
 
 [[package]]
 name = "rustix"
-version = "0.37.6"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d097081ed288dfe45699b72f5b5d648e5f15d64d900c7080273baa20c16a6849"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1330,12 +1273,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "scratch"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
-
-[[package]]
 name = "serde"
 version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,7 +1289,7 @@ checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1379,7 +1316,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.20",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -1391,7 +1328,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1432,9 +1369,9 @@ dependencies = [
 
 [[package]]
 name = "simba"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50582927ed6f77e4ac020c057f37a268fc6aebc29225050365aacbb9deeeddc4"
+checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
 dependencies = [
  "approx",
  "num-complex",
@@ -1480,9 +1417,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.5"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dccf47db1b41fa1573ed27ccf5e08e3ca771cb994f776668c5ebda893b248fc"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
@@ -1512,9 +1449,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1523,16 +1460,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
- "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1546,22 +1482,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1577,9 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "itoa",
  "serde",
@@ -1589,15 +1525,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
 dependencies = [
  "time-core",
 ]
@@ -1644,7 +1580,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1686,15 +1622,15 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.10"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-normalization"
@@ -1704,12 +1640,6 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "url"
@@ -1754,9 +1684,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1764,24 +1694,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1789,22 +1719,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "which"
@@ -1819,9 +1749,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.7"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c11d2adfe89e9da42f01023d2c2998c53aa916ef4d26ca716dbb983725c0d2"
+checksum = "5cd0496a71f3cc6bc4bf0ed91346426a5099e93d89807e663162dc5a1069ff65"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -1859,12 +1789,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.0",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets 0.42.1",
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -1878,17 +1817,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.1",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
- "windows_x86_64_gnullvm 0.42.1",
- "windows_x86_64_msvc 0.42.1",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -1908,9 +1847,9 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1920,9 +1859,9 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1932,9 +1871,9 @@ checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1944,9 +1883,9 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1956,9 +1895,9 @@ checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1968,9 +1907,9 @@ checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1980,9 +1919,9 @@ checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/crabe/Cargo.toml
+++ b/crates/crabe/Cargo.toml
@@ -8,10 +8,10 @@ default-run="crabe"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.3.0", features = ["derive"] }
-log = "0.4.18"
+clap = { version = "4.3.3", features = ["derive"] }
+log = "0.4.19"
 env_logger = "0.10.0"
-ctrlc = "3.3.1"
+ctrlc = "3.4.0"
 
 crabe_framework = { path = "../crabe_framework" }
 crabe_protocol = { path = "../crabe_protocol" }

--- a/crates/crabe/Cargo.toml
+++ b/crates/crabe/Cargo.toml
@@ -8,7 +8,7 @@ default-run="crabe"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.3.3", features = ["derive"] }
+clap = { version = "4.3.4", features = ["derive"] }
 log = "0.4.19"
 env_logger = "0.10.0"
 ctrlc = "3.4.0"

--- a/crates/crabe_decision/Cargo.toml
+++ b/crates/crabe_decision/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["NAMeC"]
 
 [dependencies]
 log = "0.4.19"
-clap = { version = "4.3.3", features = ["derive"] }
+clap = { version = "4.3.4", features = ["derive"] }
 nalgebra = "0.32.2"
 enum_dispatch = "0.3.11"
 crabe_protocol = { path = "../crabe_protocol" }

--- a/crates/crabe_decision/Cargo.toml
+++ b/crates/crabe_decision/Cargo.toml
@@ -7,8 +7,8 @@ authors = ["NAMeC"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-log = "0.4.18"
-clap = { version = "4.3.0", features = ["derive"] }
+log = "0.4.19"
+clap = { version = "4.3.3", features = ["derive"] }
 nalgebra = "0.32.2"
 enum_dispatch = "0.3.11"
 crabe_protocol = { path = "../crabe_protocol" }

--- a/crates/crabe_decision/src/action.rs
+++ b/crates/crabe_decision/src/action.rs
@@ -74,6 +74,13 @@ impl ActionWrapper {
         }
     }
 
+    /// Clears the sequence of actions to be executed of all robot.
+    pub fn clear(&mut self) {
+        self.actions.iter_mut().for_each(|(_, sequencer)| {
+            sequencer.clear();
+        })
+    }
+
     /// Computes the sequence of actions to be executed for each robot and returns a
     /// `CommandMap` containing the commands to be sent to each robot.
     ///

--- a/crates/crabe_decision/src/manager.rs
+++ b/crates/crabe_decision/src/manager.rs
@@ -2,8 +2,8 @@ use crate::action::ActionWrapper;
 use crabe_framework::data::tool::ToolData;
 use crabe_framework::data::world::World;
 
-pub mod manual;
 pub mod game_manager;
+pub mod manual;
 
 /// The `Manager` trait defines a coach that handles the SSL game and gives each robot at least one strategy.
 /// A strategy is a behavior for one or multiple robots that gives one `Action` per robot. The `Manager`'s

--- a/crates/crabe_decision/src/manager.rs
+++ b/crates/crabe_decision/src/manager.rs
@@ -3,6 +3,7 @@ use crabe_framework::data::tool::ToolData;
 use crabe_framework::data::world::World;
 
 pub mod manual;
+pub mod game_manager;
 
 /// The `Manager` trait defines a coach that handles the SSL game and gives each robot at least one strategy.
 /// A strategy is a behavior for one or multiple robots that gives one `Action` per robot. The `Manager`'s

--- a/crates/crabe_decision/src/manager/game_manager.rs
+++ b/crates/crabe_decision/src/manager/game_manager.rs
@@ -38,8 +38,10 @@ impl Manager for GameManager {
         tools_data: &mut ToolData,
         action_wrapper: &mut ActionWrapper,
     ) {
+        println!("{:?}",world.data.state);
         // info!("{:?}", &world.data.state);
         if self.last_game_state.is_none() || self.last_game_state.unwrap() != world.data.state {
+            println!("secnd phsae");
             // info!("clearing strategy");
             // clear current strategy
             self.strategies.clear();

--- a/crates/crabe_decision/src/manager/game_manager.rs
+++ b/crates/crabe_decision/src/manager/game_manager.rs
@@ -1,6 +1,7 @@
 use crate::action::ActionWrapper;
 use crate::manager::Manager;
 use crate::strategy::Strategy;
+use crate::strategy::testing::Square;
 use crabe_framework::data::tool::ToolData;
 use crabe_framework::data::world::game_state::{GameState, RunningState, StoppedState};
 use crabe_framework::data::world::World;
@@ -51,14 +52,14 @@ impl Manager for GameManager {
                     StoppedState::Stop => {
                         println!("stop");
                     }
-                    StoppedState::PrepareKickoff => {
-                        println!("prepare kick off");
+                    StoppedState::PrepareKickoff(team) => {
+                        println!("prepare kick off {:?}",team);
                     }
-                    StoppedState::PreparePenalty => {
-                        println!("prepare penalty");
+                    StoppedState::PreparePenalty(team) => {
+                        println!("prepare penalty {:?}",team);
                     }
-                    StoppedState::BallPlacement => {
-                        println!("ball placement");
+                    StoppedState::BallPlacement(team) => {
+                        println!("ball placement {:?}",team);
                     }
                 },
                 GameState::Running(running_state) => match running_state {
@@ -73,6 +74,7 @@ impl Manager for GameManager {
                     }
                     RunningState::Run => {
                         println!("run");
+                        self.strategies.push(Box::new(Square::new(1)));
                     }
                 },
             }

--- a/crates/crabe_decision/src/manager/game_manager.rs
+++ b/crates/crabe_decision/src/manager/game_manager.rs
@@ -1,4 +1,3 @@
-use log::info;
 use crate::action::ActionWrapper;
 use crate::manager::Manager;
 use crate::strategy::Strategy;
@@ -13,7 +12,8 @@ use crabe_framework::data::world::World;
 /// To add a strategy, simply create a new instance of the desired strategy and add it to the
 /// `strategies` field in the `new()` method of the `Manual` struct.
 #[derive(Default)]
-pub struct GameManager { // Karen says what to do lmao
+pub struct GameManager {
+    // Karen says what to do lmao
     last_game_state: Option<GameState>,
     strategies: Vec<Box<dyn Strategy>>,
 }
@@ -25,7 +25,7 @@ impl GameManager {
     pub fn new() -> Self {
         Self {
             last_game_state: None,
-            strategies: vec![]
+            strategies: vec![],
         }
     }
 }
@@ -38,7 +38,7 @@ impl Manager for GameManager {
         tools_data: &mut ToolData,
         action_wrapper: &mut ActionWrapper,
     ) {
-        println!("{:?}",world.data.state);
+        println!("{:?}", world.data.state);
         // info!("{:?}", &world.data.state);
         if self.last_game_state.is_none() || self.last_game_state.unwrap() != world.data.state {
             println!("secnd phsae");
@@ -53,36 +53,34 @@ impl Manager for GameManager {
                 GameState::Halted(_) => {
                     println!("halted");
                 }
-                GameState::Stopped(stopped_state) => {
-                    match stopped_state {
-                        StoppedState::Stop => {
-                            println!("stop");
-                        }
-                        StoppedState::PrepareKickoff => {
-                            println!("prepare kick off");
-                        }
-                        StoppedState::PreparePenalty => {
-                            println!("prepare penalty");}
-                        StoppedState::BallPlacement => {
-                            println!("ball placement");}
+                GameState::Stopped(stopped_state) => match stopped_state {
+                    StoppedState::Stop => {
+                        println!("stop");
                     }
-                }
-                GameState::Running(running_state) => {
-                    match running_state {
-                        RunningState::KickOff(team) => {
-                            println!("kickoff");
-                        }
-                        RunningState::Penalty => {
-                            println!("penalty");
-                        }
-                        RunningState::FreeKick => {
-                            println!("free kick");
-                        }
-                        RunningState::Run => {
-                            println!("run");
-                        }
+                    StoppedState::PrepareKickoff => {
+                        println!("prepare kick off");
                     }
-                }
+                    StoppedState::PreparePenalty => {
+                        println!("prepare penalty");
+                    }
+                    StoppedState::BallPlacement => {
+                        println!("ball placement");
+                    }
+                },
+                GameState::Running(running_state) => match running_state {
+                    RunningState::KickOff(team) => {
+                        println!("kickoff");
+                    }
+                    RunningState::Penalty => {
+                        println!("penalty");
+                    }
+                    RunningState::FreeKick => {
+                        println!("free kick");
+                    }
+                    RunningState::Run => {
+                        println!("run");
+                    }
+                },
             }
         }
 

--- a/crates/crabe_decision/src/manager/game_manager.rs
+++ b/crates/crabe_decision/src/manager/game_manager.rs
@@ -36,10 +36,9 @@ impl Manager for GameManager {
         tools_data: &mut ToolData,
         action_wrapper: &mut ActionWrapper,
     ) {
-        println!("{:?}", world.data.state);
+        //dbg!(world.data.state);
         // info!("{:?}", &world.data.state);
         if self.last_game_state.is_none() || self.last_game_state.unwrap() != world.data.state {
-            println!("secnd phsae");
             // info!("clearing strategy");
             // clear current strategy
             self.strategies.clear();

--- a/crates/crabe_decision/src/manager/game_manager.rs
+++ b/crates/crabe_decision/src/manager/game_manager.rs
@@ -1,0 +1,93 @@
+use log::info;
+use crate::action::ActionWrapper;
+use crate::manager::Manager;
+use crate::strategy::Strategy;
+use crabe_framework::data::tool::ToolData;
+use crabe_framework::data::world::game_state::{GameState, RunningState, StoppedState};
+use crabe_framework::data::world::World;
+
+/// The `Manual` struct represents a decision manager that executes strategies manually
+/// added to its list.
+/// It's used for testing individual strategies only and not meant to be used during an actual game.
+///
+/// To add a strategy, simply create a new instance of the desired strategy and add it to the
+/// `strategies` field in the `new()` method of the `Manual` struct.
+#[derive(Default)]
+pub struct GameManager { // Karen says what to do lmao
+    last_game_state: Option<GameState>,
+    strategies: Vec<Box<dyn Strategy>>,
+}
+
+const KEEPER_ID: u8 = 0;
+
+impl GameManager {
+    /// Creates a new `Manual` instance with the desired strategies to test.
+    pub fn new() -> Self {
+        Self {
+            last_game_state: None,
+            strategies: vec![]
+        }
+    }
+}
+
+impl Manager for GameManager {
+    /// Executes the list of strategies on the given `World` data, `ToolData`, and `ActionWrapper`.
+    fn step(
+        &mut self,
+        world: &World,
+        tools_data: &mut ToolData,
+        action_wrapper: &mut ActionWrapper,
+    ) {
+        // info!("{:?}", &world.data.state);
+        if self.last_game_state.is_none() || self.last_game_state.unwrap() != world.data.state {
+            // info!("clearing strategy");
+            // clear current strategy
+            self.strategies.clear();
+            for id in world.allies_bot.keys() {
+                action_wrapper.clean(*id);
+            }
+
+            match world.data.state {
+                GameState::Halted(_) => {
+                    println!("halted");
+                }
+                GameState::Stopped(stopped_state) => {
+                    match stopped_state {
+                        StoppedState::Stop => {
+                            println!("stop");
+                        }
+                        StoppedState::PrepareKickoff => {
+                            println!("prepare kick off");
+                        }
+                        StoppedState::PreparePenalty => {
+                            println!("prepare penalty");}
+                        StoppedState::BallPlacement => {
+                            println!("ball placement");}
+                    }
+                }
+                GameState::Running(running_state) => {
+                    match running_state {
+                        RunningState::KickOff(team) => {
+                            println!("kickoff");
+                        }
+                        RunningState::Penalty => {
+                            println!("penalty");
+                        }
+                        RunningState::FreeKick => {
+                            println!("free kick");
+                        }
+                        RunningState::Run => {
+                            println!("run");
+                        }
+                    }
+                }
+            }
+        }
+
+        for strategy in &mut self.strategies {
+            strategy.step(world, tools_data, action_wrapper);
+        }
+
+        self.last_game_state = Some(world.data.state);
+    }
+}

--- a/crates/crabe_decision/src/manager/game_manager.rs
+++ b/crates/crabe_decision/src/manager/game_manager.rs
@@ -13,7 +13,6 @@ use crabe_framework::data::world::World;
 /// `strategies` field in the `new()` method of the `Manual` struct.
 #[derive(Default)]
 pub struct GameManager {
-    // Karen says what to do lmao
     last_game_state: Option<GameState>,
     strategies: Vec<Box<dyn Strategy>>,
 }
@@ -42,9 +41,7 @@ impl Manager for GameManager {
             // info!("clearing strategy");
             // clear current strategy
             self.strategies.clear();
-            for id in world.allies_bot.keys() {
-                action_wrapper.clean(*id);
-            }
+            action_wrapper.clear();
 
             match world.data.state {
                 GameState::Halted(_) => {

--- a/crates/crabe_decision/src/manager/game_manager.rs
+++ b/crates/crabe_decision/src/manager/game_manager.rs
@@ -68,11 +68,11 @@ impl Manager for GameManager {
                     RunningState::KickOff(team) => {
                         println!("kickoff for {:#?}", team);
                     }
-                    RunningState::Penalty => {
-                        println!("penalty");
+                    RunningState::Penalty(team) => {
+                        println!("penalty for {:#?}", team);
                     }
-                    RunningState::FreeKick => {
-                        println!("free kick");
+                    RunningState::FreeKick(team) => {
+                        println!("free kick for {:#?}", team);
                     }
                     RunningState::Run => {
                         println!("run");

--- a/crates/crabe_decision/src/manager/game_manager.rs
+++ b/crates/crabe_decision/src/manager/game_manager.rs
@@ -2,6 +2,7 @@ use crate::action::ActionWrapper;
 use crate::manager::Manager;
 use crate::strategy::Strategy;
 use crate::strategy::testing::Square;
+use crate::strategy::testing::RobotsFormation;
 use crabe_framework::data::tool::ToolData;
 use crabe_framework::data::world::game_state::{GameState, RunningState, StoppedState};
 use crabe_framework::data::world::World;
@@ -74,7 +75,7 @@ impl Manager for GameManager {
                     }
                     RunningState::Run => {
                         println!("run");
-                        self.strategies.push(Box::new(Square::new(1)));
+                        self.strategies.push(Box::new(RobotsFormation::new(1)));
                     }
                 },
             }

--- a/crates/crabe_decision/src/manager/game_manager.rs
+++ b/crates/crabe_decision/src/manager/game_manager.rs
@@ -18,8 +18,6 @@ pub struct GameManager {
     strategies: Vec<Box<dyn Strategy>>,
 }
 
-const KEEPER_ID: u8 = 0;
-
 impl GameManager {
     /// Creates a new `Manual` instance with the desired strategies to test.
     pub fn new() -> Self {
@@ -69,7 +67,7 @@ impl Manager for GameManager {
                 },
                 GameState::Running(running_state) => match running_state {
                     RunningState::KickOff(team) => {
-                        println!("kickoff");
+                        println!("kickoff for {:#?}", team);
                     }
                     RunningState::Penalty => {
                         println!("penalty");

--- a/crates/crabe_decision/src/manager/manual.rs
+++ b/crates/crabe_decision/src/manager/manual.rs
@@ -1,6 +1,7 @@
 use crate::action::ActionWrapper;
 use crate::manager::Manager;
-use crate::strategy::testing::Square;
+// use crate::strategy::testing::Square;
+use crate::strategy::testing::RobotsFormation;
 use crate::strategy::Strategy;
 use crabe_framework::data::tool::ToolData;
 use crabe_framework::data::world::World;
@@ -20,7 +21,7 @@ impl Manual {
     /// Creates a new `Manual` instance with the desired strategies to test.
     pub fn new() -> Self {
         Self {
-            strategies: vec![Box::new(Square::new(0))],
+            strategies: vec![Box::new(RobotsFormation::new(0))],
         }
     }
 }

--- a/crates/crabe_decision/src/pipeline.rs
+++ b/crates/crabe_decision/src/pipeline.rs
@@ -1,6 +1,6 @@
 use crate::action::ActionWrapper;
 use crate::manager::game_manager::GameManager;
-use crate::manager::manual::Manual;
+
 use crate::manager::Manager;
 use clap::Args;
 use crabe_framework::component::{Component, DecisionComponent};

--- a/crates/crabe_decision/src/pipeline.rs
+++ b/crates/crabe_decision/src/pipeline.rs
@@ -1,4 +1,5 @@
 use crate::action::ActionWrapper;
+use crate::manager::game_manager::GameManager;
 use crate::manager::manual::Manual;
 use crate::manager::Manager;
 use clap::Args;
@@ -27,7 +28,7 @@ impl DecisionPipeline {
     pub fn with_config(_decision_cfg: DecisionConfig, _common_cfg: &CommonConfig) -> Self {
         Self {
             action_wrapper: ActionWrapper::default(),
-            manager: Box::new(Manual::new()),
+            manager: Box::new(GameManager::new()),
         }
     }
 }

--- a/crates/crabe_decision/src/strategy/testing.rs
+++ b/crates/crabe_decision/src/strategy/testing.rs
@@ -2,8 +2,8 @@
 /// in a counter-clockwise direction. It is used for testing purposes only and is not intended
 /// for use in a game.
 
-// mod square;
-// pub use self::square::Square;
+mod square;
+pub use self::square::Square;
 
 mod robots_formation;
 pub use self::robots_formation::RobotsFormation;

--- a/crates/crabe_decision/src/strategy/testing.rs
+++ b/crates/crabe_decision/src/strategy/testing.rs
@@ -1,5 +1,9 @@
 /// The `square` module contains a strategy that commands a robot to move in a square shape
 /// in a counter-clockwise direction. It is used for testing purposes only and is not intended
 /// for use in a game.
-mod square;
-pub use self::square::Square;
+
+// mod square;
+// pub use self::square::Square;
+
+mod robots_formation;
+pub use self::robots_formation::RobotsFormation;

--- a/crates/crabe_decision/src/strategy/testing/robots_formation.rs
+++ b/crates/crabe_decision/src/strategy/testing/robots_formation.rs
@@ -1,0 +1,62 @@
+use crate::action::move_to::MoveTo;
+use crate::action::ActionWrapper;
+use crate::strategy::Strategy;
+use crabe_framework::data::tool::ToolData;
+use crabe_framework::data::world::World;
+use nalgebra::Point2;
+use std::f64::consts::PI;
+
+/// The RobotsFormation struct represents a strategy that commands a robot to move in a RobotsFormation shape
+/// in a counter-clockwise. It is used for testing purposes.
+#[derive(Default)]
+pub struct RobotsFormation {
+    /// The id of the robot to move.
+    id: u8,
+}
+
+impl RobotsFormation {
+    /// Creates a new RobotsFormation instance with the desired robot id.
+    pub fn new(id: u8) -> Self {
+        Self { id }
+    }
+}
+
+impl Strategy for RobotsFormation {
+    /// Executes the RobotsFormation strategy.
+    ///
+    /// This strategy commands all the robots to move in the same time to test their movements
+    ///
+    /// # Arguments
+    ///
+    /// * world: The current state of the game world.
+    /// * tools_data: A collection of external tools used by the strategy, such as a viewer.    
+    /// * action_wrapper: An `ActionWrapper` instance used to issue actions to the robot.
+    ///
+    /// # Returns
+    ///
+    /// A boolean value indicating whether the strategy is finished or not.
+    #[allow(unused_variables)]
+    fn step(
+        &mut self,
+        world: &World,
+        tools_data: &mut ToolData,
+        action_wrapper: &mut ActionWrapper,
+    ) -> bool {
+        for i in 0..=3 {
+        action_wrapper.push(0, MoveTo::new(Point2::new(-1.0, 1.5), -PI / 4.0));
+        action_wrapper.push(1, MoveTo::new(Point2::new(-1.0, -1.5), -PI / 4.0));
+        action_wrapper.push(2, MoveTo::new(Point2::new(-2.0, 1.5), -PI / 4.0));
+        action_wrapper.push(3, MoveTo::new(Point2::new(-2.0, -1.5), -PI / 4.0));
+        action_wrapper.push(4, MoveTo::new(Point2::new(-3.0, 1.5), -PI / 4.0));
+        action_wrapper.push(5, MoveTo::new(Point2::new(-3.0, -1.5), -PI / 4.0));
+
+        action_wrapper.push(0, MoveTo::new(Point2::new(-1.0, 0.5), -PI / 4.0));
+        action_wrapper.push(1, MoveTo::new(Point2::new(-1.0, -0.5), -PI / 4.0));
+        action_wrapper.push(2, MoveTo::new(Point2::new(-2.0, 0.5), -PI / 4.0));
+        action_wrapper.push(3, MoveTo::new(Point2::new(-2.0, -0.5), -PI / 4.0));
+        action_wrapper.push(4, MoveTo::new(Point2::new(-3.0, 0.5), -PI / 4.0));
+        action_wrapper.push(5, MoveTo::new(Point2::new(-3.0, -0.5), -PI / 4.0));
+        }
+        true
+    }
+}

--- a/crates/crabe_filter/Cargo.toml
+++ b/crates/crabe_filter/Cargo.toml
@@ -9,10 +9,10 @@ authors = ["NAMeC"]
 [dependencies]
 log = "0.4.18"
 clap = { version = "4.3.0", features = ["derive"] }
+serde = { version= "1.0.163", features = ["derive"] }
 nalgebra = "0.32.2"
 ringbuffer = "0.13.0"
-chrono="0.4.24"
+chrono="0.4.25"
 crabe_protocol = { path = "../crabe_protocol" }
 crabe_framework = { path = "../crabe_framework" }
 crabe_math = { path = "../crabe_math"}
-serde = "1.0.163"

--- a/crates/crabe_filter/Cargo.toml
+++ b/crates/crabe_filter/Cargo.toml
@@ -7,12 +7,12 @@ authors = ["NAMeC"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-log = "0.4.18"
-clap = { version = "4.3.0", features = ["derive"] }
-serde = { version= "1.0.163", features = ["derive"] }
+log = "0.4.19"
+clap = { version = "4.3.3", features = ["derive"] }
+serde = { version= "1.0.164", features = ["derive"] }
 nalgebra = "0.32.2"
-ringbuffer = "0.13.0"
-chrono="0.4.25"
+ringbuffer = "0.14.0"
+chrono="0.4.26"
 crabe_protocol = { path = "../crabe_protocol" }
 crabe_framework = { path = "../crabe_framework" }
 crabe_math = { path = "../crabe_math"}

--- a/crates/crabe_filter/Cargo.toml
+++ b/crates/crabe_filter/Cargo.toml
@@ -15,3 +15,4 @@ chrono="0.4.24"
 crabe_protocol = { path = "../crabe_protocol" }
 crabe_framework = { path = "../crabe_framework" }
 crabe_math = { path = "../crabe_math"}
+serde = "1.0.163"

--- a/crates/crabe_filter/Cargo.toml
+++ b/crates/crabe_filter/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["NAMeC"]
 
 [dependencies]
 log = "0.4.19"
-clap = { version = "4.3.3", features = ["derive"] }
+clap = { version = "4.3.4", features = ["derive"] }
 serde = { version= "1.0.164", features = ["derive"] }
 nalgebra = "0.32.2"
 ringbuffer = "0.14.0"

--- a/crates/crabe_filter/src/constant.rs
+++ b/crates/crabe_filter/src/constant.rs
@@ -1,4 +1,4 @@
 use std::time::Duration;
 
 pub const PACKET_BUFFER_SIZE: usize = 64;
-pub const ROBOT_TIMEOUT: Duration = Duration::from_secs(2);
+pub const ROBOT_VISION_TIMEOUT: Duration = Duration::from_secs(2);

--- a/crates/crabe_filter/src/data.rs
+++ b/crates/crabe_filter/src/data.rs
@@ -3,10 +3,10 @@ pub mod referee;
 
 use crate::constant;
 use crate::data::camera::{CamBall, CamGeometry, CamRobot};
+use crate::data::referee::Referee;
 use chrono::{DateTime, Utc};
 use constant::PACKET_BUFFER_SIZE;
 use crabe_framework::data::world::{AllyInfo, Ball, EnemyInfo, Robot};
-use crabe_protocol::protobuf::game_controller_packet::Referee;
 use ringbuffer::ConstGenericRingBuffer;
 use std::collections::HashMap;
 use std::time::Instant;

--- a/crates/crabe_filter/src/data.rs
+++ b/crates/crabe_filter/src/data.rs
@@ -6,6 +6,7 @@ use crate::data::camera::{CamBall, CamGeometry, CamRobot};
 use chrono::{DateTime, Utc};
 use constant::PACKET_BUFFER_SIZE;
 use crabe_framework::data::world::{AllyInfo, Ball, EnemyInfo, Robot};
+use crate::data::referee::Referee;
 use ringbuffer::ConstGenericRingBuffer;
 use std::collections::HashMap;
 use std::time::Instant;
@@ -24,6 +25,7 @@ pub struct FilterData {
     pub enemies: TrackedRobotMap<EnemyInfo>,
     pub ball: TrackedBall,
     pub geometry: CamGeometry,
+    pub referee: Vec<Referee>,
 }
 
 pub struct TrackedRobot<T> {

--- a/crates/crabe_filter/src/data.rs
+++ b/crates/crabe_filter/src/data.rs
@@ -6,7 +6,7 @@ use crate::data::camera::{CamBall, CamGeometry, CamRobot};
 use chrono::{DateTime, Utc};
 use constant::PACKET_BUFFER_SIZE;
 use crabe_framework::data::world::{AllyInfo, Ball, EnemyInfo, Robot};
-use crate::data::referee::Referee;
+use crabe_protocol::protobuf::game_controller_packet::Referee;
 use ringbuffer::ConstGenericRingBuffer;
 use std::collections::HashMap;
 use std::time::Instant;

--- a/crates/crabe_filter/src/data.rs
+++ b/crates/crabe_filter/src/data.rs
@@ -1,4 +1,5 @@
 pub mod camera;
+pub mod referee;
 
 use crate::constant;
 use crate::data::camera::{CamBall, CamGeometry, CamRobot};

--- a/crates/crabe_filter/src/data/referee.rs
+++ b/crates/crabe_filter/src/data/referee.rs
@@ -1,0 +1,65 @@
+use std::time::Instant;
+use chrono::{DateTime, Duration, Utc};
+use nalgebra::Point2;
+use crabe_framework::data::output::Command;
+use crabe_framework::data::world::{Team, TeamColor};
+use crabe_framework::data::event::GameEvent;
+
+pub enum MatchType {
+    UnknownMatch,
+    GroupPhase,
+    EliminationPhase,
+    Friendly
+}
+
+pub struct Referee {
+    pub match_type: Option<MatchType>,
+    pub packet_timestamp: DateTime<Utc>,
+    pub stage: Stage,
+    pub stage_time_left: Option<Duration>,
+    pub command: RefereeCommand,
+    pub command_counter: u32,
+    pub command_timestamp: DateTime<Utc>,
+    pub ally: Team,
+    pub enemy: Team,
+    pub designated_position: Point2<f64>,
+    pub positive_half: Option<TeamColor>,
+    pub next_command: Option<Command>,
+    pub game_events: Vec<GameEvent>,
+    pub game_event_proposals: Vec<GameEventProposalGroup>,
+    pub current_action_time_remaining: Option<Duration>
+}
+
+pub struct GameEventProposalGroup {
+    pub game_event: Vec<GameEvent>,
+    pub accepted: Option<bool>
+}
+
+pub enum Stage {
+    NormalFirstHalfPre,
+    NormalFirstHalf,
+    NormalHalfTime,
+    NormalSecondHalfPre,
+    NormalSecondHalf,
+    ExtraTimeBreak,
+    ExtraFirstHalfPre,
+    ExtraFirstHalf,
+    ExtraHalfTime,
+    ExtraSecondHalfPre,
+    ExtraSecondHalf,
+    PenaltyShootoutBreak,
+    PenaltyShootout,
+    PostGame
+}
+
+pub enum RefereeCommand {
+    Halt,
+    Stop,
+    NormalStart,
+    ForceStart,
+    PrepareKickoff(TeamColor),
+    PreparePenalty(TeamColor),
+    DirectFree(TeamColor),
+    Timeout(TeamColor),
+    BallPlacement(TeamColor)
+}

--- a/crates/crabe_filter/src/data/referee.rs
+++ b/crates/crabe_filter/src/data/referee.rs
@@ -1,11 +1,13 @@
 use chrono::{DateTime, Duration, Utc};
 use crabe_framework::data::output::Command;
-use crabe_framework::data::world::{Team, TeamColor};
+use crabe_framework::data::world::TeamColor;
 use event::GameEvent;
 use nalgebra::Point2;
 
-mod event;
+pub mod event;
 
+/// MatchType is a meta information about the current match for easier log processing.
+#[derive(Clone, Debug)]
 pub enum MatchType {
     /// Not set
     UnknownMatch,
@@ -18,6 +20,7 @@ pub enum MatchType {
 }
 
 /// The `Referee` struct contains various information about the referee of a match.
+#[derive(Clone, Debug)]
 pub struct Referee {
     /// A random UUID of the referee that is kept constant while running.
     pub source_identifier: Option<String>,
@@ -68,6 +71,7 @@ pub struct Referee {
 }
 
 /// List of matching proposals.
+#[derive(Clone, Debug)]
 pub struct GameEventProposalGroup {
     /// The proposed game event.
     pub game_event: Vec<GameEvent>,
@@ -75,6 +79,7 @@ pub struct GameEventProposalGroup {
     pub accepted: Option<bool>,
 }
 /// `Stage` represents different stages of a game.
+#[derive(Clone, Debug)]
 pub enum Stage {
     /// Indicates that the first half is about to start.
     NormalFirstHalfPre,
@@ -108,6 +113,7 @@ pub enum Stage {
 
 /// The `RefereeCommand` enum represents a set of possible commands that a referee can issue during a game.
 /// These commands control the state of the game and dictate the actions that robots are allowed to perform at any given moment.
+#[derive(Clone, Debug)]
 pub enum RefereeCommand {
     /// Command indicating that all robots must halt movement immediately.
     Halt,
@@ -134,6 +140,8 @@ pub enum RefereeCommand {
     BallPlacement(TeamColor),
 }
 
+/// Information about a single team.
+#[derive(Clone, Debug)]
 pub struct TeamInfo {
     /// The team's name (empty string if operator has not typed anything).
     pub name: String,

--- a/crates/crabe_filter/src/data/referee.rs
+++ b/crates/crabe_filter/src/data/referee.rs
@@ -1,8 +1,10 @@
 use chrono::{DateTime, Duration, Utc};
-use crabe_framework::data::event::GameEvent;
 use crabe_framework::data::output::Command;
 use crabe_framework::data::world::{Team, TeamColor};
+use event::GameEvent;
 use nalgebra::Point2;
+
+mod event;
 
 pub enum MatchType {
     /// Not set
@@ -23,7 +25,7 @@ pub struct Referee {
     pub match_type: Option<MatchType>,
     /// The UNIX timestamp when the packet was sent, in microseconds.
     pub packet_timestamp: DateTime<Utc>,
-    /// Represent the current stage of the match.
+    /// Represent the "coarse" stages of the match.
     pub stage: Stage,
     /// The number of microseconds left in the stage.
     /// Some stage have this value :
@@ -32,19 +34,36 @@ pub struct Referee {
     /// - PENALTY_SHOOTOUT_BREAK
     /// If the stage runs over its specified time, this value becomes negative.
     pub stage_time_left: Option<Duration>,
-    /// Represent the current command sent.
+    /// These are the "fine" states of play on the field..
     pub command: RefereeCommand,
     /// The number of commands issued since startup (mod 2^32).
     pub command_counter: u32,
     /// The UNIX timestamp when the command was issued, in microseconds.
     pub command_timestamp: DateTime<Utc>,
-    pub ally: Team,
-    pub enemy: Team,
+    /// Information about the ally team.
+    pub ally: TeamInfo,
+    /// Information about the enemy team.
+    pub enemy: TeamInfo,
+    /// The coordinates of the designated Position (in millimeters).
+    /// Use only in the case of a ball placement command.
     pub designated_position: Point2<f64>,
+    /// Information about the direction of play.
+    /// True, if the blue team will have it's goal on the positive x-axis of the ssl-vision coordinate system.
+    /// Obviously, the yellow team will play on the opposite half.
     pub positive_half: Option<TeamColor>,
+    /// The command that will be issued after the current stoppage and ball placement to continue the game.
     pub next_command: Option<Command>,
+    /// All game events that were detected since the last RUNNING state.
+    /// Will be cleared as soon as the game is continued.
     pub game_events: Vec<GameEvent>,
+    /// All non-finished proposed game events that may be processed next.
     pub game_event_proposals: Vec<GameEventProposalGroup>,
+    /// The time in microseconds that is remaining until the current action times out
+    /// The time will not be reset. It can get negative.
+    /// Possible actions where this time is relevant:
+    /// - free kicks
+    /// - kickoff, penalty kick, force start
+    /// - ball placement
     pub current_action_time_remaining: Option<Duration>,
 }
 
@@ -84,14 +103,66 @@ pub enum Stage {
     PostGame,
 }
 
+/// The `RefereeCommand` enum represents a set of possible commands that a referee can issue during a game.
+/// These commands control the state of the game and dictate the actions that robots are allowed to perform at any given moment.
 pub enum RefereeCommand {
+    /// Command indicating that all robots must halt movement immediately.
     Halt,
+    /// Command instructing robots to maintain a distance of at least 50 cm from the ball.
     Stop,
+    /// Command allowing a team to proceed with a prepared kickoff or penalty shot.
     NormalStart,
+    /// Command declaring that the ball is freely accessible to any team, typically after a halt.
     ForceStart,
+    /// Command allowing the specified team to move into position for a kickoff.
     PrepareKickoff(TeamColor),
+    /// Command allowing the specified team to move into position for a penalty shot.
     PreparePenalty(TeamColor),
+    /// Command allowing the specified team to take a direct free kick.
     DirectFree(TeamColor),
+    /// Command allowing the specified team to take an indirect free kick.
+    IndirectFree(TeamColor),
+    /// Command indicating that the specified team has requested a timeout.
     Timeout(TeamColor),
+    /// Deprecated: This command indicates the specified team has scored a goal.
+    /// It's recommended to use the score field from the team infos instead for goal detection and revoked goals.
+    Goal(TeamColor),
+    /// Command equivalent to `Stop`, but the specified team must retrieve the ball and place it in a designated position.
     BallPlacement(TeamColor),
+}
+
+pub struct TeamInfo {
+    /// The team's name (empty string if operator has not typed anything).
+    pub name: String,
+    /// The number of goals scored by the team during normal play and overtime.
+    pub score: u32,
+    /// The number of red cards issued to the team since the beginning of the game.
+    pub red_cards: u32,
+    /// The amount of time (in microseconds) left on each yellow card issued to the team.
+    /// If no yellow cards are issued, this array has no elements.
+    /// Otherwise, times are ordered from smallest to largest.
+    pub yellow_card_times: Vec<u32>,
+    /// The total number of yellow cards ever issued to the team.
+    pub yellow_cards: u32,
+    /// The number of timeouts this team can still call.
+    /// If in a timeout right now, that timeout is excluded.
+    pub timeouts: u32,
+    /// The number of microseconds of timeout this team can use.
+    pub timeout_time: u32,
+    /// The pattern number of this team's goalkeeper.
+    pub goalkeeper: u32,
+    /// The total number of countable fouls that act towards yellow cards
+    pub foul_counter: Option<u32>,
+    /// The number of consecutive ball placement failures of this team
+    pub ball_placement_failures: Option<u32>,
+    /// Indicate if the team is able and allowed to place the ball
+    pub can_place_ball: Option<bool>,
+    /// The maximum number of bots allowed on the field based on division and cards
+    pub max_allowed_bots: Option<u32>,
+    /// The team has submitted an intent to substitute one or more robots at the next chance
+    pub bot_substitution_intent: Option<bool>,
+    /// Indicate if the team reached the maximum allowed ball placement failures and is thus not allowed to place the ball anymore
+    pub ball_placement_failures_reached: Option<bool>,
+    /// The team is allowed to substitute one or more robots currently
+    pub bot_substitution_allowed: Option<bool>,
 }

--- a/crates/crabe_filter/src/data/referee.rs
+++ b/crates/crabe_filter/src/data/referee.rs
@@ -113,7 +113,7 @@ pub enum Stage {
 
 /// The `RefereeCommand` enum represents a set of possible commands that a referee can issue during a game.
 /// These commands control the state of the game and dictate the actions that robots are allowed to perform at any given moment.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RefereeCommand {
     /// Command indicating that all robots must halt movement immediately.
     Halt,

--- a/crates/crabe_filter/src/data/referee.rs
+++ b/crates/crabe_filter/src/data/referee.rs
@@ -9,13 +9,13 @@ pub mod event;
 #[derive(Clone, Debug)]
 pub enum MatchType {
     /// Not set
-    UnknownMatch,
+    UnknownMatch = 0,
     /// Match is part of the group phase
-    GroupPhase,
+    GroupPhase = 1,
     /// Match is part of the elimination phase
-    EliminationPhase,
+    EliminationPhase = 2,
     /// Friendly match, not part of a tournament
-    Friendly,
+    Friendly = 3,
 }
 
 /// The `Referee` struct contains various information about the referee of a match.
@@ -79,37 +79,36 @@ pub struct GameEventProposalGroup {
 }
 /// `Stage` represents different stages of a game.
 #[derive(Clone, Debug)]
+#[repr(i32)]
 pub enum Stage {
     /// Indicates that the first half is about to start.
-    NormalFirstHalfPre,
+    NormalFirstHalfPre = 0,
     /// Indicates the first half of the normal game, before half time.
-    NormalFirstHalf,
+    NormalFirstHalf = 1,
     /// Indicates the half time period between the first and second halves.
-    NormalHalfTime,
+    NormalHalfTime = 2,
     /// Indicates that the second half is about to start.
-    NormalSecondHalfPre,
+    NormalSecondHalfPre = 3,
     /// Indicates the second half of the normal game, after half time.
-    NormalSecondHalf,
+    NormalSecondHalf = 4,
     /// Represents the break before extra time.
-    ExtraTimeBreak,
+    ExtraTimeBreak = 5,
     /// Indicates that the first half of the extra time is about to start.
-    ExtraFirstHalfPre,
+    ExtraFirstHalfPre = 6,
     /// Represents the first half of the extra time.
-    ExtraFirstHalf,
+    ExtraFirstHalf = 7,
     /// Indicates the half time period between the first and second extra halves.
-    ExtraHalfTime,
+    ExtraHalfTime = 8,
     /// Indicates that the second half of extra time is about to start.
-    ExtraSecondHalfPre,
+    ExtraSecondHalfPre = 9,
     /// Represents the second half of the extra time.
-    ExtraSecondHalf,
+    ExtraSecondHalf = 10,
     /// Represents the break period before the penalty shootout.
-    PenaltyShootoutBreak,
+    PenaltyShootoutBreak = 11,
     /// Represents the penalty shootout stage.
-    PenaltyShootout,
+    PenaltyShootout = 12,
     /// Indicates that the game has ended.
-    PostGame,
-    ///Unknow state
-    Unknow,
+    PostGame = 13,
 }
 
 /// The `RefereeCommand` enum represents a set of possible commands that a referee can issue during a game.
@@ -139,8 +138,8 @@ pub enum RefereeCommand {
     Goal(TeamColor),
     /// Command equivalent to `Stop`, but the specified team must retrieve the ball and place it in a designated position.
     BallPlacement(TeamColor),
-    ///Unknown state
-    Unknow,
+    ///Deprecated state
+    Deprecated,
 }
 
 /// Information about a single team.

--- a/crates/crabe_filter/src/data/referee.rs
+++ b/crates/crabe_filter/src/data/referee.rs
@@ -109,7 +109,7 @@ pub enum Stage {
     /// Indicates that the game has ended.
     PostGame,
     ///Unknow state
-    Unknow
+    Unknow,
 }
 
 /// The `RefereeCommand` enum represents a set of possible commands that a referee can issue during a game.
@@ -140,7 +140,7 @@ pub enum RefereeCommand {
     /// Command equivalent to `Stop`, but the specified team must retrieve the ball and place it in a designated position.
     BallPlacement(TeamColor),
     ///Unknown state
-    Unknow
+    Unknow,
 }
 
 /// Information about a single team.

--- a/crates/crabe_filter/src/data/referee.rs
+++ b/crates/crabe_filter/src/data/referee.rs
@@ -5,19 +5,38 @@ use crabe_framework::data::world::{Team, TeamColor};
 use nalgebra::Point2;
 
 pub enum MatchType {
+    /// Not set
     UnknownMatch,
+    /// Match is part of the group phase
     GroupPhase,
+    /// Match is part of the elimination phase
     EliminationPhase,
+    /// Friendly match, not part of a tournament
     Friendly,
 }
 
+/// The `Referee` struct contains various information about the referee of a match.
 pub struct Referee {
+    /// A random UUID of the referee that is kept constant while running.
+    pub source_identifier: Option<String>,
+    /// Meta information about the current match that helps to process the logs after a competition.
     pub match_type: Option<MatchType>,
+    /// The UNIX timestamp when the packet was sent, in microseconds.
     pub packet_timestamp: DateTime<Utc>,
+    /// Represent the current stage of the match.
     pub stage: Stage,
+    /// The number of microseconds left in the stage.
+    /// Some stage have this value :
+    /// - NORMAL_FIRST_HALF, NORMAL_HALF_TIME, NORMAL_SECOND_HALF
+    /// - EXTRA_TIME_BREAK EXTRA_FIRST_HALF EXTRA_HALF_TIME EXTRA_SECOND_HALF
+    /// - PENALTY_SHOOTOUT_BREAK
+    /// If the stage runs over its specified time, this value becomes negative.
     pub stage_time_left: Option<Duration>,
+    /// Represent the current command sent.
     pub command: RefereeCommand,
+    /// The number of commands issued since startup (mod 2^32).
     pub command_counter: u32,
+    /// The UNIX timestamp when the command was issued, in microseconds.
     pub command_timestamp: DateTime<Utc>,
     pub ally: Team,
     pub enemy: Team,
@@ -33,21 +52,35 @@ pub struct GameEventProposalGroup {
     pub game_event: Vec<GameEvent>,
     pub accepted: Option<bool>,
 }
-
+/// `Stage` represents different stages of a game.
 pub enum Stage {
+    /// Indicates that the first half is about to start.
     NormalFirstHalfPre,
+    /// Indicates the first half of the normal game, before half time.
     NormalFirstHalf,
+    /// Indicates the half time period between the first and second halves.
     NormalHalfTime,
+    /// Indicates that the second half is about to start.
     NormalSecondHalfPre,
+    /// Indicates the second half of the normal game, after half time.
     NormalSecondHalf,
+    /// Represents the break before extra time.
     ExtraTimeBreak,
+    /// Indicates that the first half of the extra time is about to start.
     ExtraFirstHalfPre,
+    /// Represents the first half of the extra time.
     ExtraFirstHalf,
+    /// Indicates the half time period between the first and second extra halves.
     ExtraHalfTime,
+    /// Indicates that the second half of extra time is about to start.
     ExtraSecondHalfPre,
+    /// Represents the second half of the extra time.
     ExtraSecondHalf,
+    /// Represents the break period before the penalty shootout.
     PenaltyShootoutBreak,
+    /// Represents the penalty shootout stage.
     PenaltyShootout,
+    /// Indicates that the game has ended.
     PostGame,
 }
 

--- a/crates/crabe_filter/src/data/referee.rs
+++ b/crates/crabe_filter/src/data/referee.rs
@@ -6,7 +6,12 @@ use nalgebra::Point2;
 pub mod event;
 
 /// MatchType is a meta information about the current match for easier log processing.
-#[derive(Clone, Debug)]
+#[derive(
+    Clone,
+    Copy,
+    Debug
+)]
+#[repr(i32)]
 pub enum MatchType {
     /// Not set
     UnknownMatch = 0,

--- a/crates/crabe_filter/src/data/referee.rs
+++ b/crates/crabe_filter/src/data/referee.rs
@@ -1,15 +1,14 @@
-use std::time::Instant;
 use chrono::{DateTime, Duration, Utc};
-use nalgebra::Point2;
+use crabe_framework::data::event::GameEvent;
 use crabe_framework::data::output::Command;
 use crabe_framework::data::world::{Team, TeamColor};
-use crabe_framework::data::event::GameEvent;
+use nalgebra::Point2;
 
 pub enum MatchType {
     UnknownMatch,
     GroupPhase,
     EliminationPhase,
-    Friendly
+    Friendly,
 }
 
 pub struct Referee {
@@ -27,12 +26,12 @@ pub struct Referee {
     pub next_command: Option<Command>,
     pub game_events: Vec<GameEvent>,
     pub game_event_proposals: Vec<GameEventProposalGroup>,
-    pub current_action_time_remaining: Option<Duration>
+    pub current_action_time_remaining: Option<Duration>,
 }
 
 pub struct GameEventProposalGroup {
     pub game_event: Vec<GameEvent>,
-    pub accepted: Option<bool>
+    pub accepted: Option<bool>,
 }
 
 pub enum Stage {
@@ -49,7 +48,7 @@ pub enum Stage {
     ExtraSecondHalf,
     PenaltyShootoutBreak,
     PenaltyShootout,
-    PostGame
+    PostGame,
 }
 
 pub enum RefereeCommand {
@@ -61,5 +60,5 @@ pub enum RefereeCommand {
     PreparePenalty(TeamColor),
     DirectFree(TeamColor),
     Timeout(TeamColor),
-    BallPlacement(TeamColor)
+    BallPlacement(TeamColor),
 }

--- a/crates/crabe_filter/src/data/referee.rs
+++ b/crates/crabe_filter/src/data/referee.rs
@@ -67,8 +67,11 @@ pub struct Referee {
     pub current_action_time_remaining: Option<Duration>,
 }
 
+/// List of matching proposals.
 pub struct GameEventProposalGroup {
+    /// The proposed game event.
     pub game_event: Vec<GameEvent>,
+    /// Whether the proposal group was accepted.
     pub accepted: Option<bool>,
 }
 /// `Stage` represents different stages of a game.

--- a/crates/crabe_filter/src/data/referee.rs
+++ b/crates/crabe_filter/src/data/referee.rs
@@ -1,5 +1,4 @@
 use chrono::{DateTime, Duration, Utc};
-use crabe_framework::data::output::Command;
 use crabe_framework::data::world::TeamColor;
 use event::GameEvent;
 use nalgebra::Point2;
@@ -49,13 +48,13 @@ pub struct Referee {
     pub enemy: TeamInfo,
     /// The coordinates of the designated Position (in millimeters).
     /// Use only in the case of a ball placement command.
-    pub designated_position: Point2<f64>,
+    pub designated_position: Option<Point2<f64>>,
     /// Information about the direction of play.
     /// True, if the blue team will have it's goal on the positive x-axis of the ssl-vision coordinate system.
     /// Obviously, the yellow team will play on the opposite half.
     pub positive_half: Option<TeamColor>,
     /// The command that will be issued after the current stoppage and ball placement to continue the game.
-    pub next_command: Option<Command>,
+    pub next_command: Option<RefereeCommand>,
     /// All game events that were detected since the last RUNNING state.
     /// Will be cleared as soon as the game is continued.
     pub game_events: Vec<GameEvent>,
@@ -109,6 +108,8 @@ pub enum Stage {
     PenaltyShootout,
     /// Indicates that the game has ended.
     PostGame,
+    ///Unknow state
+    Unknow
 }
 
 /// The `RefereeCommand` enum represents a set of possible commands that a referee can issue during a game.
@@ -138,6 +139,8 @@ pub enum RefereeCommand {
     Goal(TeamColor),
     /// Command equivalent to `Stop`, but the specified team must retrieve the ball and place it in a designated position.
     BallPlacement(TeamColor),
+    ///Unknown state
+    Unknow
 }
 
 /// Information about a single team.

--- a/crates/crabe_filter/src/data/referee/event.rs
+++ b/crates/crabe_filter/src/data/referee/event.rs
@@ -488,7 +488,7 @@ pub struct PlacementFailed {
     /// The team that failed.
     pub by_team: TeamColor,
     /// The remaining distance from ball to placement position (in meter).
-    pub remaining_distance: f64,
+    pub remaining_distance: Option<f64>,
 }
 
 /// Represents an event where a team collected multiple fouls, which results in a yellow card.

--- a/crates/crabe_filter/src/data/referee/event.rs
+++ b/crates/crabe_filter/src/data/referee/event.rs
@@ -1,27 +1,11 @@
-use crate::data::world::TeamColor;
 use chrono::Duration;
-
+use crabe_framework::data::world::TeamColor;
 use nalgebra::Point2;
 
 #[derive(Clone, Debug)]
 pub enum EventOrigin {
     GameController,
     Autorefs(Vec<String>),
-}
-
-#[derive(Clone, Debug)]
-pub struct BallLeftField {
-    pub by_team: TeamColor,
-    pub by_bot: Option<u32>,
-    pub location: Option<Point2<f64>>,
-}
-
-#[derive(Clone, Debug)]
-pub struct AimlessKick {
-    pub by_team: TeamColor,
-    pub by_bot: Option<u32>,
-    pub location: Option<Point2<f64>>,
-    pub kick_location: Option<Point2<f64>>,
 }
 
 #[derive(Clone, Debug)]
@@ -140,15 +124,6 @@ pub struct AttackerDoubleTouchedBall {
 }
 
 #[derive(Clone, Debug)]
-pub struct AttackerTooCloseToDefenseArea {
-    pub by_team: TeamColor,
-    pub by_bot: Option<u32>,
-    pub location: Option<Point2<f64>>,
-    pub distance: Option<f64>,
-    pub ball_location: Option<Point2<f64>>,
-}
-
-#[derive(Clone, Debug)]
 pub struct BotHeldBallDeliberately {
     pub by_team: TeamColor,
     pub by_bot: Option<u32>,
@@ -166,7 +141,7 @@ pub struct BotInterferedPlacement {
 #[derive(Clone, Debug)]
 pub struct MultipleFouls {
     pub by_team: TeamColor,
-    pub caused_game_events: Vec<GameEvent>,
+    pub caused_game_events: Vec<OldGameEvent>,
 }
 
 #[derive(Clone, Debug)]
@@ -229,8 +204,7 @@ pub struct PenaltyKickFailed {
 }
 
 #[derive(Clone, Debug)]
-pub enum GameEvent {
-    Unknown,
+pub enum OldGameEvent {
     BallLeftFieldTouchLine(BallLeftField),
     BallLeftFieldGoalLine(BallLeftField),
     AimlessKick(AimlessKick),
@@ -265,4 +239,152 @@ pub enum GameEvent {
     EmergencyStop(TeamColor),
     UnsportingBehaviorMinor(UnsportingBehaviorMinor),
     UnsportingBehaviorMajor(UnsportingBehaviorMajor),
+}
+////////////////////////
+
+/// GameEvent contains exactly one game event.
+/// Each game event has optional and required fields.
+pub struct GameEvent {
+    /// Event type of this Game
+    type_event: Option<GameEventType>,
+    /// The origins of this game event.
+    /// Empty, if it originates from game controller.
+    origin: Vec<String>,
+    /// Unix timestamp in microseconds when the event was created.
+    created_timestamp: Option<u64>,
+    /// the event that occurred
+    event: Event,
+}
+
+/// All game event type.
+/// See the protobuf message inside the crate `crabe_protocol` to see which game event is triggered by gc, auto_referee and human.
+pub enum GameEventType {
+    UnknownGameEventType,
+    BallLeftFieldTouchLine,
+    BallLeftFieldGoalLine,
+    AimlessKick,
+    AttackerTooCloseToDefenseArea,
+    DefenderInDefenseArea,
+    BoundaryCrossing,
+    KeeperHeldBall,
+    BotDribbledBallTooFar,
+    BotPushedBot,
+    BotHeldBallDeliberately,
+    BotTippedOver,
+    AttackerTouchedBallInDefenseArea,
+    BotKickedBallTooFast,
+    BotCrashUnique,
+    BotCrashDrawn,
+    DefenderTooCloseToKickPoint,
+    BotTooFastInStop,
+    BotInterferedPlacement,
+    PossibleGoal,
+    Goal,
+    InvalidGoal = 42,
+    AttackerDoubleTouchedBall,
+    PlacementSucceeded,
+    PenaltyKickFailed,
+    NoProgressInGame,
+    PlacementFailed,
+    MultipleCards,
+    MultipleFouls,
+    BotSubstitution,
+    TooManyRobots,
+    ChallengeFlag,
+    ChallengeFlagHandled,
+    EmergencyStop,
+    UnsportingBehaviorMinor,
+    UnsportingBehaviorMajor,
+    /// Since this place, all of this field is deprecated !
+    Prepared,
+    IndirectGoal,
+    ChippedGoal,
+    KickTimeout,
+    AttackerTouchedOpponentInDefenseArea,
+    AttackerTouchedOpponentInDefenseAreaSkipped,
+    BotCrashUniqueSkipped,
+    BotPushedBotSkipped,
+    DefenderInDefenseAreaPartially,
+    MultiplePlacementFailures,
+}
+
+pub enum Event {
+    // Ball out of field events (Stopping)
+    BallLeftFieldTouchLine(BallLeftField),
+    BallLeftFieldGoalLine(BallLeftField),
+    AimlessKick(AimlessKick),
+
+    // Stopping fouls
+    AttackerTooCloseToDefenseArea(AttackerTooCloseToDefenseArea),
+    DefenderInDefenseArea(DefenderInDefenseArea),
+    BoundaryCrossing(BoundaryCrossing),
+    KeeperHeldBall(KeeperHeldBall),
+    BotDribbledBallTooFar(BotDribbledBallTooFar),
+    BotPushedBot(BotPushedBot),
+    BotHeldBallDeliberately(BotHeldBallDeliberately),
+    BotTippedOver(BotTippedOver),
+    AttackerTouchedBallInDefenseArea(AttackerTouchedBallInDefenseArea),
+    BotKickedBallTooFast(BotKickedBallTooFast),
+    BotCrashUnique(BotCrashUnique),
+    BotCrashDrawn(BotCrashDrawn),
+    DefenderTooCloseToKickPoint(DefenderTooCloseToKickPoint),
+    BotTooFastInStop(BotTooFastInStop),
+    BotInterferedPlacement(BotInterferedPlacement),
+    PossibleGoal(Goal),
+    Goal(Goal),
+    InvalidGoal(Goal),
+    AttackerDoubleTouchedBall(AttackerDoubleTouchedBall),
+    PlacementSucceeded(PlacementSucceeded),
+    PenaltyKickFailed(PenaltyKickFailed),
+    NoProgressInGame(NoProgressInGame),
+    PlacementFailed(PlacementFailed),
+    MultipleCards(TeamColor),
+    MultipleFouls(MultipleFouls),
+    TooManyRobots(TooManyRobots),
+    BotSubstitution(TeamColor),
+    ChallengeFlag(TeamColor),
+    EmergencyStop(TeamColor),
+    UnsportingBehaviorMinor(UnsportingBehaviorMinor),
+    UnsportingBehaviorMajor(UnsportingBehaviorMajor),
+}
+
+//////////////////////////////////////////////////////
+//               Event Struct Type                  //
+//////////////////////////////////////////////////////
+
+#[derive(Clone, Debug)]
+pub struct BallLeftField {
+    /// The team that last touched the ball.
+    pub by_team: TeamColor,
+    /// The bot that last touched the ball.
+    pub by_bot: Option<u32>,
+    /// The location where the ball left the field (in meters).
+    pub location: Option<Point2<f64>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct AimlessKick {
+    /// The team that last touched the ball
+    pub by_team: TeamColor,
+    /// The bot that last touched the ball.
+    pub by_bot: Option<u32>,
+    /// The location where the ball left the field (in meters).
+    pub location: Option<Point2<f64>>,
+    /// The location where the ball was last touched (in meters).
+    pub kick_location: Option<Point2<f64>>,
+}
+
+/// Represents an event where an attacking robot is located too close to the opponent's defense area during a stoppage or free kick.
+#[derive(Clone, Debug)]
+pub struct AttackerTooCloseToDefenseArea {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that is too close to the defense area
+    pub by_bot: Option<u32>,
+    /// The location of the bot (in meters)
+    pub location: Option<Point2<f64>>,
+    /// The distance of the bot to the penalty area (in meters).
+    pub distance: Option<f64>,
+    /// The location of the ball at the moment when this foul occurred (in meters)
+    pub ball_location: Option<Point2<f64>>,
 }

--- a/crates/crabe_filter/src/data/referee/event.rs
+++ b/crates/crabe_filter/src/data/referee/event.rs
@@ -9,80 +9,6 @@ pub enum EventOrigin {
 }
 
 #[derive(Clone, Debug)]
-pub struct Goal {
-    pub by_team: TeamColor,
-    pub kicking_team: Option<TeamColor>,
-    pub kicking_bot: Option<u32>,
-    pub location: Option<Point2<f64>>,
-    pub kick_location: Option<Point2<f64>>,
-    pub max_ball_height: Option<f64>,
-    pub num_bots_by_team: Option<u32>,
-    pub last_touch_by_team: Option<u64>,
-    pub message: Option<String>,
-}
-
-#[derive(Clone, Debug)]
-pub struct BotTooFastInStop {
-    pub by_team: TeamColor,
-    pub by_bot: Option<u32>,
-    pub location: Option<Point2<f64>>,
-    pub speed: Option<f64>,
-}
-
-#[derive(Clone, Debug)]
-pub struct DefenderTooCloseToKickPoint {
-    pub by_team: TeamColor,
-    pub by_bot: Option<u32>,
-    pub location: Option<Point2<f64>>,
-    pub distance: Option<f64>,
-}
-
-#[derive(Clone, Debug)]
-pub struct BotCrashDrawn {
-    pub bot_blue: Option<u32>,
-    pub bot_yellow: Option<u32>,
-    pub crash_speed: Option<f64>,
-    pub speed_diff: Option<f64>,
-    pub crash_angle: Option<f64>,
-}
-
-#[derive(Clone, Debug)]
-pub struct BotCrashUnique {
-    pub by_team: TeamColor,
-    pub violator: Option<u32>,
-    pub victim: Option<u32>,
-    pub location: Option<Point2<f64>>,
-    pub crash_speed: Option<f64>,
-    pub speed_diff: Option<f64>,
-    pub crash_angle: Option<f64>,
-}
-
-#[derive(Clone, Debug)]
-pub struct BotPushedBot {
-    pub by_team: TeamColor,
-    pub violator: Option<u32>,
-    pub victim: Option<u32>,
-    pub location: Option<Point2<f64>>,
-    pub pushed_distance: Option<f64>,
-}
-
-#[derive(Clone, Debug)]
-pub struct BotTippedOver {
-    pub by_team: TeamColor,
-    pub by_bot: Option<u32>,
-    pub location: Option<Point2<f64>>,
-    pub ball_location: Option<Point2<f64>>,
-}
-
-#[derive(Clone, Debug)]
-pub struct DefenderInDefenseArea {
-    pub by_team: TeamColor,
-    pub by_bot: Option<u32>,
-    pub location: Option<Point2<f64>>,
-    pub distance: Option<f64>,
-}
-
-#[derive(Clone, Debug)]
 pub struct DefenderInDefenseAreaPartially {
     pub by_team: TeamColor,
     pub by_bot: Option<u32>,
@@ -92,56 +18,9 @@ pub struct DefenderInDefenseAreaPartially {
 }
 
 #[derive(Clone, Debug)]
-pub struct AttackerTouchedBallInDefenseArea {
-    pub by_team: TeamColor,
-    pub by_bot: Option<u32>,
-    pub location: Option<Point2<f64>>,
-    pub distance: Option<f64>,
-}
-
-#[derive(Clone, Debug)]
-pub struct BotKickedBallTooFast {
-    pub by_team: TeamColor,
-    pub by_bot: Option<u32>,
-    pub location: Option<Point2<f64>>,
-    pub initial_ball_speed: Option<f64>,
-    pub chipped: Option<bool>,
-}
-
-#[derive(Clone, Debug)]
-pub struct BotDribbledBallTooFar {
-    pub by_team: TeamColor,
-    pub by_bot: Option<u32>,
-    pub start: Option<Point2<f64>>,
-    pub end: Option<Point2<f64>>,
-}
-
-#[derive(Clone, Debug)]
-pub struct AttackerDoubleTouchedBall {
-    pub by_team: TeamColor,
-    pub by_bot: Option<u32>,
-    pub location: Option<Point2<f64>>,
-}
-
-#[derive(Clone, Debug)]
-pub struct BotHeldBallDeliberately {
-    pub by_team: TeamColor,
-    pub by_bot: Option<u32>,
-    pub location: Option<Point2<f64>>,
-    pub duration: Option<Duration>,
-}
-
-#[derive(Clone, Debug)]
-pub struct BotInterferedPlacement {
-    pub by_team: TeamColor,
-    pub by_bot: Option<u32>,
-    pub location: Option<Point2<f64>>,
-}
-
-#[derive(Clone, Debug)]
 pub struct MultipleFouls {
     pub by_team: TeamColor,
-    pub caused_game_events: Vec<OldGameEvent>,
+    pub caused_game_events: Vec<GameEvent>,
 }
 
 #[derive(Clone, Debug)]
@@ -169,21 +48,6 @@ pub struct UnsportingBehaviorMajor {
 }
 
 #[derive(Clone, Debug)]
-pub struct KeeperHeldBall {
-    pub by_team: TeamColor,
-    pub location: Option<Point2<f64>>,
-    pub duration: Option<Duration>,
-}
-
-#[derive(Clone, Debug)]
-pub struct PlacementSucceeded {
-    pub by_team: TeamColor,
-    pub time_taken: Option<f64>,
-    pub precision: Option<f64>,
-    pub distance: Option<f64>,
-}
-
-#[derive(Clone, Debug)]
 pub struct TooManyRobots {
     pub by_team: TeamColor,
     pub num_robots_allowed: Option<u32>,
@@ -192,58 +56,16 @@ pub struct TooManyRobots {
 }
 
 #[derive(Clone, Debug)]
-pub struct BoundaryCrossing {
-    pub by_team: TeamColor,
-    pub location: Option<Point2<f64>>,
-}
-
-#[derive(Clone, Debug)]
 pub struct PenaltyKickFailed {
     pub by_team: TeamColor,
     pub location: Option<Point2<f64>>,
 }
 
-#[derive(Clone, Debug)]
-pub enum OldGameEvent {
-    BallLeftFieldTouchLine(BallLeftField),
-    BallLeftFieldGoalLine(BallLeftField),
-    AimlessKick(AimlessKick),
-    AttackerTooCloseToDefenseArea(AttackerTooCloseToDefenseArea),
-    DefenderInDefenseArea(DefenderInDefenseArea),
-    BoundaryCrossing(BoundaryCrossing),
-    KeeperHeldBall(KeeperHeldBall),
-    BotDribbledBallTooFar(BotDribbledBallTooFar),
-    BotPushedBot(BotPushedBot),
-    BotHeldBallDeliberately(BotHeldBallDeliberately),
-    BotTippedOver(BotTippedOver),
-    AttackerTouchedBallInDefenseArea(AttackerTouchedBallInDefenseArea),
-    BotKickedBallTooFast(BotKickedBallTooFast),
-    BotCrashUnique(BotCrashUnique),
-    BotCrashDrawn(BotCrashDrawn),
-    DefenderTooCloseToKickPoint(DefenderTooCloseToKickPoint),
-    BotTooFastInStop(BotTooFastInStop),
-    BotInterferedPlacement(BotInterferedPlacement),
-    PossibleGoal(Goal),
-    Goal(Goal),
-    InvalidGoal(Goal),
-    AttackerDoubleTouchedBall(AttackerDoubleTouchedBall),
-    PlacementSucceeded(PlacementSucceeded),
-    PenaltyKickFailed(PenaltyKickFailed),
-    NoProgressInGame(NoProgressInGame),
-    PlacementFailed(PlacementFailed),
-    MultipleCards(TeamColor),
-    MultipleFouls(MultipleFouls),
-    TooManyRobots(TooManyRobots),
-    BotSubstitution(TeamColor),
-    ChallengeFlag(TeamColor),
-    EmergencyStop(TeamColor),
-    UnsportingBehaviorMinor(UnsportingBehaviorMinor),
-    UnsportingBehaviorMajor(UnsportingBehaviorMajor),
-}
 ////////////////////////
 
 /// GameEvent contains exactly one game event.
 /// Each game event has optional and required fields.
+#[derive(Clone, Debug)]
 pub struct GameEvent {
     /// Event type of this Game
     type_event: Option<GameEventType>,
@@ -258,6 +80,7 @@ pub struct GameEvent {
 
 /// All game event type.
 /// See the protobuf message inside the crate `crabe_protocol` to see which game event is triggered by gc, auto_referee and human.
+#[derive(Clone, Debug)]
 pub enum GameEventType {
     UnknownGameEventType,
     BallLeftFieldTouchLine,
@@ -295,19 +118,10 @@ pub enum GameEventType {
     EmergencyStop,
     UnsportingBehaviorMinor,
     UnsportingBehaviorMajor,
-    /// Since this place, all of this field is deprecated !
-    Prepared,
-    IndirectGoal,
-    ChippedGoal,
-    KickTimeout,
-    AttackerTouchedOpponentInDefenseArea,
-    AttackerTouchedOpponentInDefenseAreaSkipped,
-    BotCrashUniqueSkipped,
-    BotPushedBotSkipped,
-    DefenderInDefenseAreaPartially,
-    MultiplePlacementFailures,
+    Deprecated,
 }
 
+#[derive(Clone, Debug)]
 pub enum Event {
     // Ball out of field events (Stopping)
     BallLeftFieldTouchLine(BallLeftField),
@@ -320,22 +134,32 @@ pub enum Event {
     BoundaryCrossing(BoundaryCrossing),
     KeeperHeldBall(KeeperHeldBall),
     BotDribbledBallTooFar(BotDribbledBallTooFar),
+
     BotPushedBot(BotPushedBot),
     BotHeldBallDeliberately(BotHeldBallDeliberately),
     BotTippedOver(BotTippedOver),
+
+    // Non-Stopping Fouls
     AttackerTouchedBallInDefenseArea(AttackerTouchedBallInDefenseArea),
     BotKickedBallTooFast(BotKickedBallTooFast),
     BotCrashUnique(BotCrashUnique),
     BotCrashDrawn(BotCrashDrawn),
+
+    // Fouls while ball out of play
     DefenderTooCloseToKickPoint(DefenderTooCloseToKickPoint),
     BotTooFastInStop(BotTooFastInStop),
     BotInterferedPlacement(BotInterferedPlacement),
+
+    // Scoring goals
     PossibleGoal(Goal),
     Goal(Goal),
     InvalidGoal(Goal),
+
+    // Other events
     AttackerDoubleTouchedBall(AttackerDoubleTouchedBall),
     PlacementSucceeded(PlacementSucceeded),
     PenaltyKickFailed(PenaltyKickFailed),
+
     NoProgressInGame(NoProgressInGame),
     PlacementFailed(PlacementFailed),
     MultipleCards(TeamColor),
@@ -346,31 +170,35 @@ pub enum Event {
     EmergencyStop(TeamColor),
     UnsportingBehaviorMinor(UnsportingBehaviorMinor),
     UnsportingBehaviorMajor(UnsportingBehaviorMajor),
+
+    DeprecatedEvent,
 }
 
 //////////////////////////////////////////////////////
 //               Event Struct Type                  //
 //////////////////////////////////////////////////////
 
+/// Represents an event where the ball left the field normally.
 #[derive(Clone, Debug)]
 pub struct BallLeftField {
     /// The team that last touched the ball.
     pub by_team: TeamColor,
     /// The bot that last touched the ball.
     pub by_bot: Option<u32>,
-    /// The location where the ball left the field (in meters).
+    /// The location where the ball left the field (in meter).
     pub location: Option<Point2<f64>>,
 }
 
+/// Represents an event where the ball left the field via goal line and a team committed an aimless kick.
 #[derive(Clone, Debug)]
 pub struct AimlessKick {
     /// The team that last touched the ball
     pub by_team: TeamColor,
     /// The bot that last touched the ball.
     pub by_bot: Option<u32>,
-    /// The location where the ball left the field (in meters).
+    /// The location where the ball left the field (in meter).
     pub location: Option<Point2<f64>>,
-    /// The location where the ball was last touched (in meters).
+    /// The location where the ball was last touched (in meter).
     pub kick_location: Option<Point2<f64>>,
 }
 
@@ -379,12 +207,245 @@ pub struct AimlessKick {
 pub struct AttackerTooCloseToDefenseArea {
     /// The team that found guilty.
     pub by_team: TeamColor,
-    /// The bot that is too close to the defense area
+    /// The bot that is too close to the defense area.
     pub by_bot: Option<u32>,
-    /// The location of the bot (in meters)
+    /// The location of the bot (in meter).
     pub location: Option<Point2<f64>>,
-    /// The distance of the bot to the penalty area (in meters).
+    /// The distance of the bot to the penalty area (in meter).
     pub distance: Option<f64>,
-    /// The location of the ball at the moment when this foul occurred (in meters)
+    /// The location of the ball at the moment when this foul occurred (in meter).
     pub ball_location: Option<Point2<f64>>,
+}
+
+/// Represents an event where a defender other than the keeper was fully located inside its own defense and touched the ball.
+#[derive(Clone, Debug)]
+pub struct DefenderInDefenseArea {
+    /// The team that found guilty
+    pub by_team: TeamColor,
+    /// The bot that is inside the penalty area
+    pub by_bot: Option<u32>,
+    /// The location of the bot (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The distance from bot case to the nearest point outside the defense area (in meter).
+    pub distance: Option<f64>,
+}
+
+/// Represents an event where a robot chipped the ball over the field boundary out of the playing surface.
+#[derive(Clone, Debug)]
+pub struct BoundaryCrossing {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The location of the ball (in meter).
+    pub location: Option<Point2<f64>>,
+}
+
+/// Represents an event where a keeper held the ball in its defense area for too long.
+#[derive(Clone, Debug)]
+pub struct KeeperHeldBall {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The location of the ball (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The duration that the keeper hold the ball (in seconds).
+    pub duration: Option<Duration>,
+}
+
+/// Represents an event where a bot dribbled to ball too far.
+#[derive(Clone, Debug)]
+pub struct BotDribbledBallTooFar {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that dribbled too far.
+    pub by_bot: Option<u32>,
+    /// The location where the dribbling started (in meter).
+    pub start: Option<Point2<f64>>,
+    /// The location where the maximum dribbling distance was reached (in meter).
+    pub end: Option<Point2<f64>>,
+}
+
+/// Represents an event where a bot pushed another bot over a significant distance.
+#[derive(Clone, Debug)]
+pub struct BotPushedBot {
+    /// The team that pushed the other team.
+    pub by_team: TeamColor,
+    /// The bot that pushed the other bot.
+    pub violator: Option<u32>,
+    /// The bot of the opposite team that was pushed.
+    pub victim: Option<u32>,
+    /// The location of the push (center between both bots) (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The pushed distance (in meter).
+    pub pushed_distance: Option<f64>,
+}
+
+/// Represents an event where a bot held the ball for too long.
+#[derive(Clone, Debug)]
+pub struct BotHeldBallDeliberately {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that holds the ball.
+    pub by_bot: Option<u32>,
+    /// The location of the ball (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The duration that the bot hold the ball (in seconds).
+    pub duration: Option<Duration>,
+}
+
+/// Represents an event where a bot tipped over.
+#[derive(Clone, Debug)]
+pub struct BotTippedOver {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that tipped over.
+    pub by_bot: Option<u32>,
+    /// The location of the bot (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The location of the ball at the moment when this foul occurred (in meter).
+    pub ball_location: Option<Point2<f64>>,
+}
+
+/// Represents an event where an attacker touched the ball inside the opponent defense area.
+#[derive(Clone, Debug)]
+pub struct AttackerTouchedBallInDefenseArea {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that is inside the penalty area.
+    pub by_bot: Option<u32>,
+    /// The location of the bot (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The distance that the bot is inside the penalty area (in meter).
+    pub distance: Option<f64>,
+}
+
+/// Represents an event where a bot kicked the ball too fast.
+#[derive(Clone, Debug)]
+pub struct BotKickedBallTooFast {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that kicked too fast.
+    pub by_bot: Option<u32>,
+    /// The location of the ball at the time of the highest speed (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The absolute initial ball speed (kick speed) (in meter per second).
+    pub initial_ball_speed: Option<f64>,
+    /// Was the ball chipped?
+    pub chipped: Option<bool>,
+}
+
+/// Represents an event where two robots crashed into each other and one team was found guilty to due significant speed difference.
+#[derive(Clone, Debug)]
+pub struct BotCrashUnique {
+    /// The team that caused the crash.
+    pub by_team: TeamColor,
+    /// The bot that caused the crash.
+    pub violator: Option<u32>,
+    /// The bot of the opposite team that was involved in the crash.
+    pub victim: Option<u32>,
+    /// The location of the crash (center between both bots) (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The calculated crash speed vector of the two bots (in meter per second).
+    pub crash_speed: Option<f64>,
+    /// The difference of the velocity of the two bots (in meter per second).
+    pub speed_diff: Option<f64>,
+    /// the angle [rad] in the range [0, π] of the bot velocity vectors
+    /// an angle of 0 rad (  0°) means, the bots barely touched each other
+    /// an angle of π rad (180°) means, the bots crashed frontal into each other
+    pub crash_angle: Option<f64>,
+}
+/// Represents an event where two robots crashed into each other with similar speeds
+#[derive(Clone, Debug)]
+pub struct BotCrashDrawn {
+    /// The bot of the yellow team.
+    pub bot_yellow: Option<u32>,
+    /// The bot of the blue team.
+    pub bot_blue: Option<u32>,
+    /// The location of the crash (center between both bots) (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The calculated crash speed of the two bots (in meter per second).
+    pub crash_speed: Option<f64>,
+    /// The difference of the velocity of the two bots (in meter per second).
+    pub speed_diff: Option<f64>,
+    /// the angle [rad] in the range [0, π] of the bot velocity vectors
+    /// an angle of 0 rad (  0°) means, the bots barely touched each other
+    /// an angle of π rad (180°) means, the bots crashed frontal into each other.
+    pub crash_angle: Option<f64>,
+}
+
+/// Represents an event where a bot of the defending team got too close to the kick point during a free kick.
+#[derive(Clone, Debug)]
+pub struct DefenderTooCloseToKickPoint {
+    /// The team that was found guilty.
+    pub by_team: TeamColor,
+    /// The bot that violates the distance to the kick point.
+    pub by_bot: Option<u32>,
+    /// The location of the bot (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The distance from bot to the kick point (including the minimum radius) (in meter).
+    pub distance: Option<f64>,
+}
+
+/// Represents an event where a bot moved too fast while the game was stopped.
+#[derive(Clone, Debug)]
+pub struct BotTooFastInStop {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that was too fast.
+    pub by_bot: Option<u32>,
+    /// The location of the bot (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The bot speed (in meter per second).
+    pub speed: Option<f64>,
+}
+
+/// Represents an event where a bot interfered the ball placement of the other team.
+#[derive(Clone, Debug)]
+pub struct BotInterferedPlacement {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that interfered the placement.
+    pub by_bot: Option<u32>,
+    /// The location of the bot (in meter).
+    pub location: Option<Point2<f64>>,
+}
+
+/// Represents an event where a team shot a goal
+#[derive(Clone, Debug)]
+pub struct Goal {
+    /// The team that scored the goal.
+    pub by_team: TeamColor,
+    /// The team that shot the goal (different from by_team for own goals).
+    pub kicking_team: Option<TeamColor>,
+    /// The bot that shot the goal.
+    pub kicking_bot: Option<u32>,
+    /// The location where the ball entered the goal (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The location where the ball was kicked (for deciding if this was a valid goal) (in meter).
+    pub kick_location: Option<Point2<f64>>,
+    /// The maximum height the ball reached during the goal kick (for deciding if this was a valid goal) (in meter).
+    pub max_ball_height: Option<f64>,
+    /// Number of robots of scoring team when the ball entered the goal (for deciding if this was a valid goal).
+    pub num_bots_by_team: Option<u32>,
+    /// The UNIX timestamp when the scoring team last touched the ball (in microsecond).
+    pub last_touch_by_team: Option<u64>,
+    /// An additional message with e.g. a reason for invalid goals.
+    pub message: Option<String>,
+}
+
+/// Represents an event where an attacker touched the ball multiple times when it was not allowed to.
+#[derive(Clone, Debug)]
+pub struct AttackerDoubleTouchedBall {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that touched the ball twice.
+    pub by_bot: Option<u32>,
+    /// The location of the ball when it was first touched (in meter).
+    pub location: Option<Point2<f64>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct PlacementSucceeded {
+    pub by_team: TeamColor,
+    pub time_taken: Option<f64>,
+    pub precision: Option<f64>,
+    pub distance: Option<f64>,
 }

--- a/crates/crabe_filter/src/data/referee/event.rs
+++ b/crates/crabe_filter/src/data/referee/event.rs
@@ -1,5 +1,7 @@
 use chrono::Duration;
 use crabe_framework::data::world::TeamColor;
+use crabe_protocol::protobuf::game_controller_packet;
+use crabe_protocol::protobuf::game_controller_packet::game_event::Type;
 use nalgebra::Point2;
 
 /// GameEvent contains exactly one game event.
@@ -17,11 +19,22 @@ pub struct GameEvent {
     pub event: Event,
 }
 
+impl From<game_controller_packet::GameEvent> for GameEvent {
+    fn from(packet: game_controller_packet::GameEvent) -> Self {
+        Self {
+            type_event: Option::from(GameEventType::from(packet.r#type())),
+            origin: vec![],
+            created_timestamp: None,
+            event: Event::DeprecatedEvent,
+        }
+    }
+}
+
 /// All game event type.
 /// See the protobuf message inside the crate `crabe_protocol` to see which game event is triggered by gc, auto_referee and human.
 #[derive(Clone, Debug)]
 pub enum GameEventType {
-    UnknownGameEventType,
+    Unknown,
     BallLeftFieldTouchLine,
     BallLeftFieldGoalLine,
     AimlessKick,
@@ -42,7 +55,7 @@ pub enum GameEventType {
     BotInterferedPlacement,
     PossibleGoal,
     Goal,
-    InvalidGoal = 42,
+    InvalidGoal,
     AttackerDoubleTouchedBall,
     PlacementSucceeded,
     PenaltyKickFailed,
@@ -58,6 +71,61 @@ pub enum GameEventType {
     UnsportingBehaviorMinor,
     UnsportingBehaviorMajor,
     Deprecated,
+}
+
+impl From<Type> for GameEventType {
+    fn from(packet: Type) -> Self {
+        match packet {
+            Type::UnknownGameEventType => GameEventType::Unknown,
+            Type::BallLeftFieldTouchLine => GameEventType::BallLeftFieldTouchLine,
+            Type::BallLeftFieldGoalLine => GameEventType::BallLeftFieldGoalLine,
+            Type::AimlessKick => GameEventType::AimlessKick,
+            Type::AttackerTooCloseToDefenseArea => GameEventType::AttackerTooCloseToDefenseArea,
+            Type::DefenderInDefenseArea => GameEventType::DefenderInDefenseArea,
+            Type::BoundaryCrossing => GameEventType::BoundaryCrossing,
+            Type::KeeperHeldBall => GameEventType::KeeperHeldBall,
+            Type::BotDribbledBallTooFar => GameEventType::BotDribbledBallTooFar,
+            Type::BotPushedBot => GameEventType::BotPushedBot,
+            Type::BotHeldBallDeliberately => GameEventType::BotHeldBallDeliberately,
+            Type::BotTippedOver => GameEventType::BotTippedOver,
+            Type::AttackerTouchedBallInDefenseArea => {
+                GameEventType::AttackerTouchedBallInDefenseArea
+            }
+            Type::BotKickedBallTooFast => GameEventType::BotKickedBallTooFast,
+            Type::BotCrashUnique => GameEventType::BotCrashUnique,
+            Type::BotCrashDrawn => GameEventType::BotCrashDrawn,
+            Type::DefenderTooCloseToKickPoint => GameEventType::DefenderTooCloseToKickPoint,
+            Type::BotTooFastInStop => GameEventType::BotTooFastInStop,
+            Type::BotInterferedPlacement => GameEventType::BotInterferedPlacement,
+            Type::PossibleGoal => GameEventType::PossibleGoal,
+            Type::Goal => GameEventType::Goal,
+            Type::InvalidGoal => GameEventType::InvalidGoal,
+            Type::AttackerDoubleTouchedBall => GameEventType::AttackerDoubleTouchedBall,
+            Type::PlacementSucceeded => GameEventType::PlacementSucceeded,
+            Type::PenaltyKickFailed => GameEventType::PenaltyKickFailed,
+            Type::NoProgressInGame => GameEventType::NoProgressInGame,
+            Type::PlacementFailed => GameEventType::PlacementFailed,
+            Type::MultipleCards => GameEventType::MultipleCards,
+            Type::MultipleFouls => GameEventType::MultipleFouls,
+            Type::BotSubstitution => GameEventType::BotSubstitution,
+            Type::TooManyRobots => GameEventType::TooManyRobots,
+            Type::ChallengeFlag => GameEventType::ChallengeFlag,
+            Type::ChallengeFlagHandled => GameEventType::ChallengeFlagHandled,
+            Type::EmergencyStop => GameEventType::EmergencyStop,
+            Type::UnsportingBehaviorMinor => GameEventType::UnsportingBehaviorMinor,
+            Type::UnsportingBehaviorMajor => GameEventType::UnsportingBehaviorMajor,
+            Type::Prepared => GameEventType::Deprecated,
+            Type::IndirectGoal => GameEventType::Deprecated,
+            Type::ChippedGoal => GameEventType::Deprecated,
+            Type::KickTimeout => GameEventType::Deprecated,
+            Type::AttackerTouchedOpponentInDefenseArea => GameEventType::Deprecated,
+            Type::AttackerTouchedOpponentInDefenseAreaSkipped => GameEventType::Deprecated,
+            Type::BotCrashUniqueSkipped => GameEventType::Deprecated,
+            Type::BotPushedBotSkipped => GameEventType::Deprecated,
+            Type::DefenderInDefenseAreaPartially => GameEventType::Deprecated,
+            Type::MultiplePlacementFailures => GameEventType::Deprecated,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/crabe_filter/src/data/referee/event.rs
+++ b/crates/crabe_filter/src/data/referee/event.rs
@@ -7,14 +7,14 @@ use nalgebra::Point2;
 #[derive(Clone, Debug)]
 pub struct GameEvent {
     /// Event type of this Game
-    type_event: Option<GameEventType>,
+    pub type_event: Option<GameEventType>,
     /// The origins of this game event.
     /// Empty, if it originates from game controller.
-    origin: Vec<EventOrigin>,
+    pub origin: Vec<EventOrigin>,
     /// Unix timestamp in microseconds when the event was created.
-    created_timestamp: Option<u64>,
+    pub created_timestamp: Option<u64>,
     /// the event that occurred
-    event: Event,
+    pub event: Event,
 }
 
 /// All game event type.

--- a/crates/crabe_filter/src/data/referee/event.rs
+++ b/crates/crabe_filter/src/data/referee/event.rs
@@ -2,67 +2,6 @@ use chrono::Duration;
 use crabe_framework::data::world::TeamColor;
 use nalgebra::Point2;
 
-#[derive(Clone, Debug)]
-pub enum EventOrigin {
-    GameController,
-    Autorefs(Vec<String>),
-}
-
-#[derive(Clone, Debug)]
-pub struct DefenderInDefenseAreaPartially {
-    pub by_team: TeamColor,
-    pub by_bot: Option<u32>,
-    pub location: Option<Point2<f64>>,
-    pub distance: Option<f64>,
-    pub ball_location: Option<Point2<f64>>,
-}
-
-#[derive(Clone, Debug)]
-pub struct MultipleFouls {
-    pub by_team: TeamColor,
-    pub caused_game_events: Vec<GameEvent>,
-}
-
-#[derive(Clone, Debug)]
-pub struct NoProgressInGame {
-    pub location: Option<Point2<f64>>,
-    pub time: Option<Duration>,
-}
-
-#[derive(Clone, Debug)]
-pub struct PlacementFailed {
-    pub location: Option<Point2<f64>>,
-    pub remaining_distance: f64,
-}
-
-#[derive(Clone, Debug)]
-pub struct UnsportingBehaviorMinor {
-    pub by_team: TeamColor,
-    pub reason: String,
-}
-
-#[derive(Clone, Debug)]
-pub struct UnsportingBehaviorMajor {
-    pub by_team: TeamColor,
-    pub reason: String,
-}
-
-#[derive(Clone, Debug)]
-pub struct TooManyRobots {
-    pub by_team: TeamColor,
-    pub num_robots_allowed: Option<u32>,
-    pub num_robots_on_field: Option<u32>,
-    pub ball_location: Option<Point2<f64>>,
-}
-
-#[derive(Clone, Debug)]
-pub struct PenaltyKickFailed {
-    pub by_team: TeamColor,
-    pub location: Option<Point2<f64>>,
-}
-
-////////////////////////
-
 /// GameEvent contains exactly one game event.
 /// Each game event has optional and required fields.
 #[derive(Clone, Debug)]
@@ -71,7 +10,7 @@ pub struct GameEvent {
     type_event: Option<GameEventType>,
     /// The origins of this game event.
     /// Empty, if it originates from game controller.
-    origin: Vec<String>,
+    origin: Vec<EventOrigin>,
     /// Unix timestamp in microseconds when the event was created.
     created_timestamp: Option<u64>,
     /// the event that occurred
@@ -442,10 +381,91 @@ pub struct AttackerDoubleTouchedBall {
     pub location: Option<Point2<f64>>,
 }
 
+/// Represents an event where a team successfully placed the ball.
 #[derive(Clone, Debug)]
 pub struct PlacementSucceeded {
+    /// The team that did the placement.
     pub by_team: TeamColor,
+    /// The time taken for placing the ball (in second).
     pub time_taken: Option<f64>,
+    /// The distance between placement location and actual ball position (in meter).
     pub precision: Option<f64>,
+    /// The distance between the initial ball location and the placement position (in meter).
     pub distance: Option<f64>,
+}
+
+/// Represents an event where the penalty kick failed (by time or by keeper).
+#[derive(Clone, Debug)]
+pub struct PenaltyKickFailed {
+    /// The team that last touched the ball.
+    pub by_team: TeamColor,
+    /// The location of the ball at the moment of this event (in minute).
+    pub location: Option<Point2<f64>>,
+    /// An explanation of the failure.
+    pub reason: Option<String>,
+}
+
+/// Represents an event where game was stuck.
+#[derive(Clone, Debug)]
+pub struct NoProgressInGame {
+    /// The location of the ball.
+    pub location: Option<Point2<f64>>,
+    /// The time that was waited (in second).
+    pub time: Option<Duration>,
+}
+
+/// Represents an event where the ball placement failed.
+#[derive(Clone, Debug)]
+pub struct PlacementFailed {
+    /// The team that failed.
+    pub by_team: TeamColor,
+    /// The remaining distance from ball to placement position (in meter).
+    pub remaining_distance: f64,
+}
+
+/// Represents an event where a team collected multiple fouls, which results in a yellow card.
+#[derive(Clone, Debug)]
+pub struct MultipleFouls {
+    /// The team that collected multiple fouls.
+    pub by_team: TeamColor,
+    /// The list of game events that caused the multiple fouls.
+    pub caused_game_events: Vec<GameEvent>,
+}
+
+/// Represents an event where a team has too many robots on the field.
+#[derive(Clone, Debug)]
+pub struct TooManyRobots {
+    /// The team that has too many robots.
+    pub by_team: TeamColor,
+    /// Number of robots allowed at the moment.
+    pub num_robots_allowed: Option<u32>,
+    /// Number of robots currently on the field.
+    pub num_robots_on_field: Option<u32>,
+    /// The location of the ball at the moment when this foul occurred (in meter).
+    pub ball_location: Option<Point2<f64>>,
+}
+
+/// Represents an event where a team was found guilty for minor unsporting behavior.
+#[derive(Clone, Debug)]
+pub struct UnsportingBehaviorMinor {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// An explanation of the situation and decision.
+    pub reason: String,
+}
+
+/// Represents an event where a team was found guilty for minor unsporting behavior.
+#[derive(Clone, Debug)]
+pub struct UnsportingBehaviorMajor {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// An explanation of the situation and decision.
+    pub reason: String,
+}
+
+/// Enum that represent the origin of the event.
+#[derive(Clone, Debug)]
+pub enum EventOrigin {
+    GameController,
+    Autorefs(Vec<String>),
 }

--- a/crates/crabe_filter/src/filter/inactive.rs
+++ b/crates/crabe_filter/src/filter/inactive.rs
@@ -27,7 +27,7 @@ impl InactiveFilter {
 impl Default for InactiveFilter {
     fn default() -> Self {
         Self {
-            timeout: constant::ROBOT_TIMEOUT,
+            timeout: constant::ROBOT_VISION_TIMEOUT,
         }
     }
 }

--- a/crates/crabe_filter/src/filter/inactive.rs
+++ b/crates/crabe_filter/src/filter/inactive.rs
@@ -10,10 +10,6 @@ pub struct InactiveFilter {
 }
 
 impl InactiveFilter {
-    pub fn new(timeout: Duration) -> Self {
-        Self { timeout }
-    }
-
     fn purge_inactive<T>(&self, tracked_robots: &mut TrackedRobotMap<T>, now: DateTime<Utc>) {
         tracked_robots.retain(|_id, robot| {
             // Use std duration as chrono does not support const fn yet

--- a/crates/crabe_filter/src/lib.rs
+++ b/crates/crabe_filter/src/lib.rs
@@ -6,7 +6,6 @@ mod pre_filter;
 
 use crate::data::FilterData;
 
-use crate::filter::inactive::InactiveFilter;
 use crate::filter::passthrough::PassthroughFilter;
 use crate::filter::Filter;
 use crate::post_filter::ball::BallFilter;
@@ -15,12 +14,15 @@ use crate::post_filter::robot::RobotFilter;
 use crate::post_filter::game_controller::GameControllerPostFilter;
 use crate::post_filter::PostFilter;
 use crate::pre_filter::vision::VisionFilter;
+use crate::pre_filter::game_controller::GameControllerPreFilter;
 use crate::pre_filter::PreFilter;
 use clap::Args;
 use crabe_framework::component::{Component, FilterComponent};
 use crabe_framework::config::CommonConfig;
 use crabe_framework::data::input::InboundData;
 use crabe_framework::data::world::{TeamColor, World};
+use crabe_io::pipeline::input::InputConfig;
+use crate::filter::inactive::InactiveFilter;
 
 #[derive(Args)]
 pub struct FilterConfig {}
@@ -34,9 +36,9 @@ pub struct FilterPipeline {
 }
 
 impl FilterPipeline {
-    pub fn with_config(_config: FilterConfig, common_config: &CommonConfig) -> Self {
+    pub fn with_config(_config: FilterConfig, common_config: &CommonConfig, input_config: &InputConfig) -> Self {
         let mut pre_filters: Vec<Box<dyn PreFilter>> = vec![Box::new(VisionFilter::new())];
-        let filters: Vec<Box<dyn Filter>> = vec![Box::new(PassthroughFilter), Box::new(VelocityAccelerationFilter), Box::new(InactiveFilter::default())];
+        let filters: Vec<Box<dyn Filter>> = vec![Box::new(PassthroughFilter),  Box::new(InactiveFilter::default())];
         let mut post_filters: Vec<Box<dyn PostFilter>> = vec![
                 Box::new(RobotFilter),
                 Box::new(GeometryFilter),

--- a/crates/crabe_filter/src/lib.rs
+++ b/crates/crabe_filter/src/lib.rs
@@ -77,10 +77,10 @@ impl Component for FilterPipeline {
 }
 
 impl FilterComponent for FilterPipeline {
-    fn step(&mut self, inbound_data: InboundData, world: &mut World) {
+    fn step(&mut self, mut inbound_data: InboundData, world: &mut World) {
         self.pre_filters
             .iter_mut()
-            .for_each(|f| f.step(&inbound_data, &self.team_color, &mut self.filter_data));
+            .for_each(|f| f.step(&mut inbound_data, &self.team_color, &mut self.filter_data));
 
         self.filters
             .iter_mut()

--- a/crates/crabe_filter/src/lib.rs
+++ b/crates/crabe_filter/src/lib.rs
@@ -12,6 +12,7 @@ use crate::filter::Filter;
 use crate::post_filter::ball::BallFilter;
 use crate::post_filter::geometry::GeometryFilter;
 use crate::post_filter::robot::RobotFilter;
+use crate::post_filter::game_controller::GameControllerPostFilter;
 use crate::post_filter::PostFilter;
 use crate::pre_filter::vision::VisionFilter;
 use crate::pre_filter::PreFilter;
@@ -44,6 +45,7 @@ impl FilterPipeline {
                 Box::new(RobotFilter),
                 Box::new(GeometryFilter),
                 Box::new(BallFilter),
+                Box::new(GameControllerPostFilter),
             ],
             filter_data: FilterData {
                 allies: Default::default(),

--- a/crates/crabe_filter/src/lib.rs
+++ b/crates/crabe_filter/src/lib.rs
@@ -39,7 +39,7 @@ impl FilterPipeline {
         let mut pre_filters: Vec<Box<dyn PreFilter>> = vec![Box::new(VisionFilter::new())];
         let filters: Vec<Box<dyn Filter>> = vec![
             Box::new(PassthroughFilter),
-            Box::new(InactiveFilter::default()),
+            Box::<InactiveFilter>::default(),
         ];
         let mut post_filters: Vec<Box<dyn PostFilter>> = vec![
             Box::new(RobotFilter),
@@ -49,7 +49,7 @@ impl FilterPipeline {
 
         if common_config.gc {
             pre_filters.push(Box::new(GameControllerPreFilter));
-            post_filters.push(Box::new(GameControllerPostFilter::default()));
+            post_filters.push(Box::<GameControllerPostFilter>::default());
         }
 
         Self {

--- a/crates/crabe_filter/src/lib.rs
+++ b/crates/crabe_filter/src/lib.rs
@@ -6,23 +6,22 @@ mod pre_filter;
 
 use crate::data::FilterData;
 
+use crate::filter::inactive::InactiveFilter;
 use crate::filter::passthrough::PassthroughFilter;
 use crate::filter::Filter;
 use crate::post_filter::ball::BallFilter;
+use crate::post_filter::game_controller::GameControllerPostFilter;
 use crate::post_filter::geometry::GeometryFilter;
 use crate::post_filter::robot::RobotFilter;
-use crate::post_filter::game_controller::GameControllerPostFilter;
 use crate::post_filter::PostFilter;
-use crate::pre_filter::vision::VisionFilter;
 use crate::pre_filter::game_controller::GameControllerPreFilter;
+use crate::pre_filter::vision::VisionFilter;
 use crate::pre_filter::PreFilter;
 use clap::Args;
 use crabe_framework::component::{Component, FilterComponent};
 use crabe_framework::config::CommonConfig;
 use crabe_framework::data::input::InboundData;
 use crabe_framework::data::world::{TeamColor, World};
-use crabe_io::pipeline::input::InputConfig;
-use crate::filter::inactive::InactiveFilter;
 
 #[derive(Args)]
 pub struct FilterConfig {}
@@ -36,16 +35,19 @@ pub struct FilterPipeline {
 }
 
 impl FilterPipeline {
-    pub fn with_config(_config: FilterConfig, common_config: &CommonConfig, input_config: &InputConfig) -> Self {
+    pub fn with_config(_config: FilterConfig, common_config: &CommonConfig) -> Self {
         let mut pre_filters: Vec<Box<dyn PreFilter>> = vec![Box::new(VisionFilter::new())];
-        let filters: Vec<Box<dyn Filter>> = vec![Box::new(PassthroughFilter),  Box::new(InactiveFilter::default())];
+        let filters: Vec<Box<dyn Filter>> = vec![
+            Box::new(PassthroughFilter),
+            Box::new(InactiveFilter::default()),
+        ];
         let mut post_filters: Vec<Box<dyn PostFilter>> = vec![
-                Box::new(RobotFilter),
-                Box::new(GeometryFilter),
-                Box::new(BallFilter),
-            ];
+            Box::new(RobotFilter),
+            Box::new(GeometryFilter),
+            Box::new(BallFilter),
+        ];
 
-        if input_config.gc {
+        if common_config.gc {
             pre_filters.push(Box::new(GameControllerPreFilter));
             post_filters.push(Box::new(GameControllerPostFilter::default()));
         }
@@ -59,7 +61,7 @@ impl FilterPipeline {
                 enemies: Default::default(),
                 ball: Default::default(),
                 geometry: Default::default(),
-                referee: Default::default()
+                referee: Default::default(),
             },
             team_color: if common_config.yellow {
                 TeamColor::Yellow

--- a/crates/crabe_filter/src/lib.rs
+++ b/crates/crabe_filter/src/lib.rs
@@ -50,6 +50,7 @@ impl FilterPipeline {
                 enemies: Default::default(),
                 ball: Default::default(),
                 geometry: Default::default(),
+                referee: Default::default(),
             },
             team_color: if common_config.yellow {
                 TeamColor::Yellow

--- a/crates/crabe_filter/src/lib.rs
+++ b/crates/crabe_filter/src/lib.rs
@@ -35,24 +35,29 @@ pub struct FilterPipeline {
 
 impl FilterPipeline {
     pub fn with_config(_config: FilterConfig, common_config: &CommonConfig) -> Self {
-        Self {
-            pre_filters: vec![Box::new(VisionFilter::new())],
-            filters: vec![
-                Box::new(PassthroughFilter),
-                Box::new(InactiveFilter::default()),
-            ],
-            post_filters: vec![
+        let mut pre_filters: Vec<Box<dyn PreFilter>> = vec![Box::new(VisionFilter::new())];
+        let filters: Vec<Box<dyn Filter>> = vec![Box::new(PassthroughFilter), Box::new(VelocityAccelerationFilter), Box::new(InactiveFilter::default())];
+        let mut post_filters: Vec<Box<dyn PostFilter>> = vec![
                 Box::new(RobotFilter),
                 Box::new(GeometryFilter),
                 Box::new(BallFilter),
-                Box::new(GameControllerPostFilter),
-            ],
+            ];
+
+        if input_config.gc {
+            pre_filters.push(Box::new(GameControllerPreFilter));
+            post_filters.push(Box::new(GameControllerPostFilter::default()));
+        }
+
+        Self {
+            pre_filters,
+            filters,
+            post_filters,
             filter_data: FilterData {
                 allies: Default::default(),
                 enemies: Default::default(),
                 ball: Default::default(),
                 geometry: Default::default(),
-                referee: Default::default(),
+                referee: Default::default()
             },
             team_color: if common_config.yellow {
                 TeamColor::Yellow

--- a/crates/crabe_filter/src/post_filter.rs
+++ b/crates/crabe_filter/src/post_filter.rs
@@ -1,7 +1,7 @@
 pub mod ball;
 pub mod geometry;
 pub mod robot;
-//pub mod game_controller;
+pub mod game_controller;
 
 use crate::data::FilterData;
 use crabe_framework::data::world::World;

--- a/crates/crabe_filter/src/post_filter.rs
+++ b/crates/crabe_filter/src/post_filter.rs
@@ -1,6 +1,7 @@
 pub mod ball;
 pub mod geometry;
 pub mod robot;
+//pub mod game_controller;
 
 use crate::data::FilterData;
 use crabe_framework::data::world::World;

--- a/crates/crabe_filter/src/post_filter.rs
+++ b/crates/crabe_filter/src/post_filter.rs
@@ -1,7 +1,7 @@
 pub mod ball;
+pub mod game_controller;
 pub mod geometry;
 pub mod robot;
-pub mod game_controller;
 
 use crate::data::FilterData;
 use crabe_framework::data::world::World;

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -1,6 +1,7 @@
 use std::time::Instant;
 use std::u8;
-use chrono::Duration;
+use serde::{Serialize, Deserialize};
+use crabe_protocol;
 use crabe_framework::data::world::game_state::{GameState, HaltedState, RunningState, StoppedState};
 use crate::data::FilterData;
 use crate::post_filter::PostFilter;
@@ -17,7 +18,7 @@ pub struct GameControllerPostFilter {
     previous_game_event: crabe_protocol::protobuf::game_controller_packet::GameEvent,
     // previous_event: Option<Event>,
     // chrono: Option<Instant>,
-    #[serde(skipSerialization)]
+    //#[serde(skip_serializing)]
     previous_event: Option<Event>,
     chrono: Option<Instant>,
     kicked_off_once: bool
@@ -182,7 +183,7 @@ impl PostFilter for GameControllerPostFilter {
         self.fix_yourself();
 
         filter_data.referee.last();
-
+        println!("filter game con");
         // grab data
         let last_referee_packet = match filter_data.referee.last() {
             None => {

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -246,9 +246,6 @@ impl PostFilter for GameControllerPostFilter {
             self.previous_game_event = previous_game_event.clone();
             self.previous_event = previous_game_event.event.clone(); //todo: don't clone this, specify lifetime
         }
-
-        let referee_command = last_referee_packet.command();
-
         // if let Some(blue_team_on_positive_half) = last_referee_packet.blue_team_on_positive_half {
         //     if blue_team_on_positive_half {
         //        world.data.positive_half = TeamColor::Blue
@@ -256,108 +253,5 @@ impl PostFilter for GameControllerPostFilter {
         //         world.data.positive_half = TeamColor::Yellow
         //     }
         // };
-        //
-        // // from any state
-        // if let Command::Halt = referee_command {
-        //     world.data.state = GameState::Halted(HaltedState::Halt);
-        // }
-        //
-        // match referee_command {
-        //     Command::Halt => {
-        //         world.data.state = GameState::Halted(HaltedState::Halt);
-        //     }
-        //     Command::Stop => {
-        //         world.data.state = GameState::Stopped(StoppedState::Stop);
-        //     }
-        //     _ => {}
-        // }
-        //
-        // let mut kicker_team = None;
-        //
-        // match &world.data.state {
-        //     GameState::Halted(_) => {
-        //     }
-        //     GameState::Stopped(stopped_state) => {
-        //         match stopped_state {
-        //             StoppedState::Stop => {
-        //                 // TODO: prepare kickoffs :(
-        //                 match referee_command {
-        //                     Command::ForceStart => {
-        //                         world.data.state = GameState::Running(RunningState::Run);
-        //                     }
-        //                     Command::PrepareKickoffBlue => {
-        //                         kicker_team = Some(TeamColor::Blue);
-        //                         if world.team_color == TeamColor::Blue {
-        //                             world.data.state = GameState::Stopped(StoppedState::PrepareKickoff);
-        //                         } else {
-        //                             world.data.state = GameState::Stopped(StoppedState::Stop);
-        //                         }
-        //                     }
-        //                     Command::PrepareKickoffYellow => {
-        //                         kicker_team = Some(TeamColor::Yellow);
-        //                         if world.team_color == TeamColor::Yellow {
-        //                             world.data.state = GameState::Stopped(StoppedState::PrepareKickoff);
-        //                         } else {
-        //                             world.data.state = GameState::Stopped(StoppedState::Stop);
-        //                         }
-        //                     }
-        //                     Command::PreparePenaltyBlue => {}
-        //                     Command::PreparePenaltyYellow => {}
-        //                     Command::NormalStart => {
-        //                         world.data.state = GameState::Running(RunningState::KickOff(kicker_team.unwrap_or(TeamColor::Blue))); // FIX THIS auto color under too
-        //                     }
-        //                     _ => {}
-        //                 }
-        //             }
-        //             StoppedState::PrepareKickoff => {
-        //                 if let Command::NormalStart = referee_command {
-        //                     world.data.state = GameState::Running(RunningState::KickOff(kicker_team.unwrap_or(TeamColor::Blue)));
-        //                 }
-        //             }
-        //             StoppedState::PreparePenalty => {
-        //                 if let Command::NormalStart = referee_command {
-        //                     world.data.state = GameState::Running(RunningState::KickOff(kicker_team.unwrap_or(TeamColor::Blue)));
-        //                 }
-        //             }
-        //             StoppedState::BallPlacement => {
-        //                 // TODO: what the fuck ?
-        //                 // if let Command::Continue {
-        //                 //     world.data.state = GameState::Running(RunningState::KickOff);
-        //                 // }
-        //             }
-        //         }
-        //     }
-        //     GameState::Running(running_state) => {
-        //         match running_state {
-        //             RunningState::KickOff(_) => {
-        //                 if let Some(ball) = &world.ball {
-        //                     if ball.velocity.xy().norm() > 0.3 {
-        //                         world.data.state = GameState::Running(RunningState::Run);
-        //                     }
-        //                 }
-        //                 if let Some(chrono) = &self.chrono {
-        //                     if chrono.elapsed() > std::time::Duration::from_secs(10) {
-        //                         world.data.state = GameState::Running(RunningState::Run);
-        //                     }
-        //                 } else {
-        //                     // start chrono
-        //                     self.chrono = Some(Instant::now());
-        //                 }
-        //                 // if let Command::AfterXSecondsOrIfBallMoved {
-        //                 //     world.data.state = GameState::Running(RunningState::Run);
-        //                 // }
-        //             }
-        //             RunningState::FreeKick => {
-        //                 // if let Command::AfterXSecondsOrIfBallMoved {
-        //                 //     world.data.state = GameState::Running(RunningState::Run);
-        //                 // }
-        //             }
-        //             _ => {}
-        //         }
-        //     }
-        // }
-        //
-        //dbg!(referee_command);
-        //dbg!(&world.data.state);
     }
 }

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -98,16 +98,14 @@ impl GameControllerPostFilter {
                     world.data.state = GameState::Halted(HaltedState::Halt);
                 }
                 
+                //Non stopping fouls
                 Event::AttackerTouchedBallInDefenseArea(_) => {
-                    //Non stopping fouls
                     dbg!("AttackerTouchedBallInDefenseArea");
                 }
                 Event::BotKickedBallTooFast(_) => {
-                    //Non stopping fouls
                     dbg!("BotKickedBallTooFast");
                 }
                 Event::BotCrashUnique(_) => {
-                    //Non stopping fouls
                     dbg!("BotCrashUnique");
                 }
                 Event::BotCrashDrawn(_) |
@@ -122,7 +120,6 @@ impl GameControllerPostFilter {
                 Event::ChallengeFlag(_) |
                 Event::EmergencyStop(_) |
                 Event::DeprecatedEvent => {
-                    // TODO: the "world.team_color" isn't right
                     world.data.state = GameState::Stopped(StoppedState::Stop);
                 }
             }

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -85,7 +85,7 @@ impl GameControllerPostFilter {
                 // this one's totally arbitrary
                 // i don't understand how we can fetch a forced free kick from the commands
                 // todo: fix what's mentioned above me (fix me !)
-                world.data.state = GameState::Running(RunningState::FreeKick);
+                world.data.state = GameState::Running(RunningState::FreeKick(TeamColor::Blue));
             }
         }
     }
@@ -106,6 +106,7 @@ impl GameControllerPostFilter {
         world: &mut World,
         mut chrono: Option<Instant>,
     ) {
+        //TODO team color
         if let Some(previous_event) = previous_event_opt {
             match previous_event {
                 Event::Goal(g) => {
@@ -115,7 +116,6 @@ impl GameControllerPostFilter {
                     if let Some(chrono) = chrono {
                         println!("Kickoff in progress ! It lasts for 10s at most");
                         if chrono.elapsed() > std::time::Duration::from_secs(10) {
-                            //TODO
                             //let kickoff_team = g.by_team as TeamColor;
                             //world.data.state = GameState::Running(RunningState::KickOff(kickoff_team));
                             world.data.state =
@@ -160,7 +160,7 @@ impl GameControllerPostFilter {
                 chrono_opt = Some(Instant::now());
             } else {
                 // otherwise, we are still in the FreeKick state
-                world.data.state = GameState::Running(RunningState::FreeKick);
+                world.data.state = GameState::Running(RunningState::FreeKick(TeamColor::Blue));
             }
         }
     }
@@ -173,19 +173,19 @@ impl GameControllerPostFilter {
                 chrono_opt = Some(Instant::now());
             } else {
                 // otherwise, we are still in the FreeKick state
-                world.data.state = GameState::Running(RunningState::FreeKick);
+                world.data.state = GameState::Running(RunningState::FreeKick(TeamColor::Yellow));
             }
         }
     }
 
     fn prepare_penalty_yellow_branch(world: &mut World, mut chrono_opt: Option<Instant>) {
         //TODO : idk the penalty comportement
-        world.data.state = GameState::Running(RunningState::Penalty);
+        world.data.state = GameState::Running(RunningState::Penalty(TeamColor::Yellow));
     }
 
     fn prepare_penalty_blue_branch(world: &mut World, mut chrono_opt: Option<Instant>) {
         //TODO : idk the penalty comportement
-        world.data.state = GameState::Running(RunningState::Penalty);
+        world.data.state = GameState::Running(RunningState::Penalty(TeamColor::Blue));
     }
 
     fn ball_placement_yellow_branch(world: &mut World, chrono_opt: Option<Instant>) {

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -4,7 +4,6 @@ use crabe_framework::data::world::game_state::{
     GameState, HaltedState, RunningState, StoppedState,
 };
 use crabe_framework::data::world::{TeamColor, World};
-use crabe_protocol;
 
 use crate::data::referee::event::{Event, GameEvent};
 use crate::data::referee::RefereeCommand;

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -186,7 +186,6 @@ impl PostFilter for GameControllerPostFilter {
         self.fix_yourself();
 
         filter_data.referee.last();
-        println!("filter game con");
         // grab data
         let last_referee_packet = match filter_data.referee.last() {
             None => {

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -72,14 +72,14 @@ impl GameControllerPostFilter {
                     world.data.state = GameState::Stopped(StoppedState::BallPlacement(left_field_infos.by_team.opposite()));
                 }
                 //TODO : check if all these events have to be stopped
-                Event::KeeperHeldBall(keeper_held_ball_infos) => {
+                Event::AttackerTooCloseToDefenseArea(_) |
+                Event::BoundaryCrossing(_) |
+                Event::BotDribbledBallTooFar(_) |
+                Event::KeeperHeldBall(_) => {
                     world.data.state = GameState::Stopped(StoppedState::Stop);
                 }
                 Event::AimlessKick(_) |
-                Event::AttackerTooCloseToDefenseArea(_) |
                 Event::DefenderInDefenseArea(_) |
-                Event::BoundaryCrossing(_) |
-                Event::BotDribbledBallTooFar(_) |
                 Event::BotPushedBot(_) |
                 Event::BotHeldBallDeliberately(_) |
                 Event::BotTippedOver(_) |

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -73,8 +73,7 @@ impl GameControllerPostFilter {
                 }
                 //TODO : check if all these events have to be stopped
                 Event::KeeperHeldBall(keeper_held_ball_infos) => {
-                    //TODO : we don't know if we just take a yellow card of if we have to go in halt
-                    world.data.state = GameState::Halted(HaltedState::Halt);
+                    world.data.state = GameState::Stopped(StoppedState::Stop);
                 }
                 Event::AimlessKick(_) |
                 Event::AttackerTooCloseToDefenseArea(_) |

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -72,11 +72,14 @@ impl GameControllerPostFilter {
                     world.data.state = GameState::Stopped(StoppedState::BallPlacement(left_field_infos.by_team.opposite()));
                 }
                 //TODO : check if all these events have to be stopped
+                Event::KeeperHeldBall(keeper_held_ball_infos) => {
+                    //TODO : we don't know if we just take a yellow card of if we have to go in halt
+                    world.data.state = GameState::Halted(HaltedState::Halt);
+                }
                 Event::AimlessKick(_) |
                 Event::AttackerTooCloseToDefenseArea(_) |
                 Event::DefenderInDefenseArea(_) |
                 Event::BoundaryCrossing(_) |
-                Event::KeeperHeldBall(_) |
                 Event::BotDribbledBallTooFar(_) |
                 Event::BotPushedBot(_) |
                 Event::BotHeldBallDeliberately(_) |

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -65,11 +65,9 @@ impl GameControllerPostFilter {
                 Event::Goal(goal_infos)=> {
                     world.data.state = GameState::Stopped(StoppedState::PrepareKickoff(goal_infos.by_team.opposite()));
                 }
-                //TODO : team color idk if it's opposite or ?
                 Event::BallLeftFieldTouchLine(left_field_infos) => {
                     world.data.state = GameState::Stopped(StoppedState::BallPlacement(left_field_infos.by_team.opposite()));
                 }
-
                 Event::BallLeftFieldGoalLine(left_field_infos) => {
                     world.data.state = GameState::Stopped(StoppedState::BallPlacement(left_field_infos.by_team.opposite()));
                 }

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -98,9 +98,18 @@ impl GameControllerPostFilter {
                     world.data.state = GameState::Halted(HaltedState::Halt);
                 }
                 
-                Event::AttackerTouchedBallInDefenseArea(_) |
-                Event::BotKickedBallTooFast(_) |
-                Event::BotCrashUnique(_) |
+                Event::AttackerTouchedBallInDefenseArea(_) => {
+                    //Non stopping fouls
+                    dbg!("AttackerTouchedBallInDefenseArea");
+                }
+                Event::BotKickedBallTooFast(_) => {
+                    //Non stopping fouls
+                    dbg!("BotKickedBallTooFast");
+                }
+                Event::BotCrashUnique(_) => {
+                    //Non stopping fouls
+                    dbg!("BotCrashUnique");
+                }
                 Event::BotCrashDrawn(_) |
                 Event::DefenderTooCloseToKickPoint(_) |
                 Event::BotTooFastInStop(_) |

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -8,7 +8,6 @@ use log::warn;
 
 use crate::data::referee::event::{Event, GameEvent};
 use crate::data::referee::RefereeCommand;
-use std::cell::Ref;
 use std::time::Instant;
 
 #[derive(Debug)]
@@ -54,7 +53,7 @@ impl GameControllerPostFilter {
 
     fn stop_state_branch(
         previous_game_event_opt: &Option<GameEvent>,
-        previous_command: &RefereeCommand,
+        _previous_command: &RefereeCommand,
         world: &mut World,
         _kicked_off_once: &mut bool,
         mut _chrono: Option<Instant>,
@@ -130,8 +129,8 @@ impl GameControllerPostFilter {
     }
 
     fn force_start_state_branch(
-        previous_event_opt: &Option<Event>,
-        previous_command: RefereeCommand,
+        _previous_event_opt: &Option<Event>,
+        _previous_command: RefereeCommand,
         world: &mut World,
         mut _chrono: Option<Instant>,
     ) {

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -52,7 +52,7 @@ impl GameControllerPostFilter {
     }
 
     fn stop_state_branch(
-        previous_game_event_opt: &Option<GameEvent>,
+        previous_game_event_opt: &Option<&GameEvent>,
         _previous_command: &RefereeCommand,
         world: &mut World,
         _kicked_off_once: &mut bool,
@@ -243,12 +243,13 @@ impl PostFilter for GameControllerPostFilter {
 
         let ref_command = last_referee_packet.command.clone();
         //TODO : not sure about the indirect free refCommand
+        //dbg!(&ref_command);
         match ref_command {
             RefereeCommand::Halt => GameControllerPostFilter::halt_state_branch(world),
             RefereeCommand::Deprecated |
             RefereeCommand::IndirectFree(_) |
             RefereeCommand::Stop => {
-                GameControllerPostFilter::stop_state_branch(&self.previous_game_event, &self.previous_command, world, &mut self.kicked_off_once, self.chrono,)
+                GameControllerPostFilter::stop_state_branch(&last_referee_packet.game_events.last(), &self.previous_command, world, &mut self.kicked_off_once, self.chrono,)
             },
             RefereeCommand::NormalStart => {
                 GameControllerPostFilter::normal_start_state_branch(&self.previous_event, self.previous_command.clone(), world, self.chrono,)

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -115,8 +115,9 @@ impl GameControllerPostFilter {
                     if let Some(chrono) = chrono {
                         println!("Kickoff in progress ! It lasts for 10s at most");
                         if chrono.elapsed() > std::time::Duration::from_secs(10) {
-                            // let kickoff_team = g.by_team as TeamColor;
-                            // world.data.state = GameState::Running(RunningState::KickOff(kickoff_team));
+                            //TODO
+                            //let kickoff_team = g.by_team as TeamColor;
+                            //world.data.state = GameState::Running(RunningState::KickOff(kickoff_team));
                             world.data.state =
                                 GameState::Running(RunningState::KickOff(TeamColor::Blue));
                         }

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -274,13 +274,11 @@ impl PostFilter for GameControllerPostFilter {
         }
         self.last_command = ref_command.clone();
 
-        // todo: Don't forget to update positive half
-        // if let Some(blue_team_on_positive_half) = last_referee_packet.blue_team_on_positive_half {
-        //     if blue_team_on_positive_half {
-        //        world.data.positive_half = TeamColor::Blue
-        //     } else {
-        //         world.data.positive_half = TeamColor::Yellow
-        //     }
-        // };
+        //update positive half team
+        if let Some(team_on_positive_half) = last_referee_packet.positive_half {
+            world.data.positive_half = team_on_positive_half
+        }
+
+        //TODO : ally and enemy
     }
 }

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -1,0 +1,333 @@
+use std::time::Instant;
+use std::u8;
+use chrono::Duration;
+use crabe_framework::data::world::game_state::{GameState, HaltedState, RunningState, StoppedState};
+use crate::data::FilterData;
+use crate::post_filter::PostFilter;
+use crabe_framework::data::world::{TeamColor, World};
+use crabe_protocol::protobuf::game_controller_packet::game_event::Event;
+use crabe_protocol::protobuf::game_controller_packet::Referee;
+use crabe_protocol::protobuf::game_controller_packet::referee::Command;
+use crabe_framework::data::event::GameEvent;
+use crate::data::referee::RefereeCommand;
+use crate::data::referee::RefereeCommand::Stop;
+
+#[derive(Debug)]
+pub struct GameControllerPostFilter {
+    previous_game_event: crabe_protocol::protobuf::game_controller_packet::GameEvent,
+    // previous_event: Option<Event>,
+    // chrono: Option<Instant>,
+    #[serde(skipSerialization)]
+    previous_event: Option<Event>,
+    chrono: Option<Instant>,
+    kicked_off_once: bool
+}
+
+impl Default for GameControllerPostFilter {
+    fn default() -> Self {
+        GameControllerPostFilter {
+            previous_game_event: Default::default(),
+            previous_event: None,
+            chrono: Option::from(Instant::now()),
+            kicked_off_once: false,
+        }
+    }
+}
+
+/// Contains all the possible actions that we may be able
+/// to execute from a referee command
+/// The job of these functions is just to change
+/// the current world state according to the command
+/// and the last event that occurred
+impl GameControllerPostFilter {
+    fn fix_yourself(&mut self) {
+        if self.chrono == None {
+            self.chrono = Option::from(Instant::now());
+        }
+    }
+
+    fn halt_state_branch(world: &mut World) {
+        // Halt event, all robots should stop
+        // Done: 2/2
+        // consider that timeout is equivalent to normal halt
+        world.data.state = GameState::Halted(HaltedState::Halt);
+        println!("Stop all robots");
+    }
+
+    fn stop_state_branch(previous_event_opt: &Option<Event>, world: &mut World, mut kicked_off_once: bool) {
+        // TODO: 3/4 ?
+        if let Some(previous_event) = previous_event_opt {
+            match previous_event {
+                // Goal has been scored, prepare for next kickoff phase
+                Event::Goal { .. } => {
+                    world.data.state = GameState::Stopped(StoppedState::PrepareKickoff);
+                    println!("Prepare for kickoff");
+                }
+
+                Event::BallLeftFieldTouchLine { .. } => {
+                    world.data.state = GameState::Stopped(StoppedState::BallPlacement);
+                    println!("Ball got out of the field by the touch lines !");
+                }
+
+                Event::BallLeftFieldGoalLine { .. } => {
+                    world.data.state = GameState::Stopped(StoppedState::BallPlacement);
+                    println!("Ball got out of the field by the goal lines !");
+                }
+
+                &_ => {}
+            }
+        } else {
+            // Particularly, it should be None when we just started the match
+            // Thus, it's a kickoff
+            if !kicked_off_once {
+                world.data.state = GameState::Stopped(StoppedState::PrepareKickoff);
+                kicked_off_once = true;
+            } else {
+                // this one's totally arbitrary
+                // i don't understand how we can fetch a forced free kick from the commands
+                // todo: fix what's mentioned above me (fix me !)
+                world.data.state = GameState::Running(RunningState::FreeKick);
+            }
+        }
+    }
+
+    fn normal_start_state_branch(previous_event_opt: &Option<Event>, world: &mut World, mut chrono: Option<Instant>) {
+        if let Some(previous_event) = previous_event_opt {
+            match previous_event {
+                Event::Goal(g) => {
+                    dbg!(g.by_team);
+                    // Kickoff is in progress by a team, place accordingly on your side
+                    // 10s until we go into normal state
+                    if let Some(chrono) = chrono {
+                        println!("Kickoff in progress ! It lasts for 10s at most");
+                        if chrono.elapsed() > std::time::Duration::from_secs(10) {
+                            // let kickoff_team = g.by_team as TeamColor;
+                            // world.data.state = GameState::Running(RunningState::KickOff(kickoff_team));
+                            world.data.state = GameState::Running(RunningState::KickOff(TeamColor::Blue));
+                        }
+                    } else {
+                        println!("Running normally after kickoff");
+                        // start chrono
+                        chrono = Some(Instant::now());
+                        world.data.state = GameState::Running(RunningState::Run);
+                    }
+                }
+
+                &_ => {
+                    // Just play the game when no particular state is found
+                    // - what's your problem green ?
+                    // - me said alone ramp, me said alone ramp
+                    // - (proceeds to destroy his table)
+                    world.data.state = GameState::Running(RunningState::Run);
+                }
+            }
+        } else {
+            println!("Play by default");
+            world.data.state = GameState::Running(RunningState::Run);
+        }
+    }
+
+    fn timeout_yellow_branch(world: &mut World) {
+        world.data.state = GameState::Halted(HaltedState::Timeout);
+    }
+    fn timeout_blue_branch(world: &mut World) {
+        world.data.state = GameState::Halted(HaltedState::Timeout);
+    }
+
+    fn freekick_blue_branch(world: &mut World, mut chrono_opt: Option<Instant>) {
+        if let Some(chrono) = chrono_opt {
+            // if 10s have passed, game runs normally
+            if chrono.elapsed() > std::time::Duration::from_secs(10) {
+                world.data.state = GameState::Running(RunningState::Run);
+                chrono_opt = Some(Instant::now());
+            } else {
+                // otherwise, we are still in the FreeKick state
+                world.data.state = GameState::Running(RunningState::FreeKick);
+            }
+        }
+        chrono_opt = Option::from(Instant::now());
+        GameControllerPostFilter::freekick_blue_branch(world, chrono_opt);
+        unreachable!("Chrono is None!");
+    }
+
+    fn freekick_yellow_branch(world: &mut World, mut chrono_opt: Option<Instant>) {
+        if let Some(chrono) = chrono_opt {
+            if chrono.elapsed() > std::time::Duration::from_secs(10) {
+                world.data.state = GameState::Running(RunningState::Run);
+                chrono_opt = Some(Instant::now());
+            } else {
+                world.data.state = GameState::Running(RunningState::FreeKick);
+            }
+        }
+    }
+
+    fn ball_placement_blue_branch(world: &mut World, chrono_opt: Option<Instant>) {
+        if let Some(chrono) = chrono_opt {
+            // [ALLEMAGNE] chrono check peut être enlevé si pas de ball placement auto
+            if chrono.elapsed() >= std::time::Duration::from_secs(30) {
+                world.data.state = GameState::Running(RunningState::Run);
+            } else {
+                world.data.state = GameState::Stopped(StoppedState::BallPlacement);
+            }
+        }
+        // The chrono should always be available to us
+        unreachable!();
+    }
+}
+
+
+
+impl PostFilter for GameControllerPostFilter {
+    fn step(&mut self, filter_data: &FilterData, world: &mut World) {
+        self.fix_yourself();
+
+        filter_data.referee.last();
+
+        // grab data
+        let last_referee_packet = match filter_data.referee.last() {
+            None => {
+                return;
+            }
+            Some(r) => r
+        };
+
+        // Note de journal: 4h44
+        // - touche une pute :D
+        // dbg!(last_referee_packet);
+        let ref_command = last_referee_packet.command();
+
+        // dbg!(&ref_command);
+        dbg!(&self.previous_event);
+
+        match ref_command {
+            Command::Halt => GameControllerPostFilter::halt_state_branch(world),
+            Command::Stop => GameControllerPostFilter::stop_state_branch(&self.previous_event, world, self.kicked_off_once),
+            Command::NormalStart => GameControllerPostFilter::normal_start_state_branch(&self.previous_event, world, self.chrono),
+            Command::TimeoutBlue => GameControllerPostFilter::timeout_blue_branch(world),
+            Command::TimeoutYellow => GameControllerPostFilter::timeout_yellow_branch(world),
+            Command::DirectFreeBlue => GameControllerPostFilter::freekick_blue_branch(world, self.chrono),
+            Command::DirectFreeYellow => GameControllerPostFilter::freekick_yellow_branch(world, self.chrono),
+            Command::BallPlacementBlue => GameControllerPostFilter::ball_placement_blue_branch(world, self.chrono),
+            _ => {}
+        }
+
+        // Update previous gamestate & event
+        if let Some(previous_game_event) = last_referee_packet.game_events.last() {
+            self.previous_game_event = previous_game_event.clone();
+            self.previous_event = previous_game_event.event.clone(); //todo: don't clone this, specify lifetime
+        }
+
+        let referee_command = last_referee_packet.command();
+
+        // if let Some(blue_team_on_positive_half) = last_referee_packet.blue_team_on_positive_half {
+        //     if blue_team_on_positive_half {
+        //        world.data.positive_half = TeamColor::Blue
+        //     } else {
+        //         world.data.positive_half = TeamColor::Yellow
+        //     }
+        // };
+        //
+        // // from any state
+        // if let Command::Halt = referee_command {
+        //     world.data.state = GameState::Halted(HaltedState::Halt);
+        // }
+        //
+        // match referee_command {
+        //     Command::Halt => {
+        //         world.data.state = GameState::Halted(HaltedState::Halt);
+        //     }
+        //     Command::Stop => {
+        //         world.data.state = GameState::Stopped(StoppedState::Stop);
+        //     }
+        //     _ => {}
+        // }
+        //
+        // let mut kicker_team = None;
+        //
+        // match &world.data.state {
+        //     GameState::Halted(_) => {
+        //     }
+        //     GameState::Stopped(stopped_state) => {
+        //         match stopped_state {
+        //             StoppedState::Stop => {
+        //                 // TODO: prepare kickoffs :(
+        //                 match referee_command {
+        //                     Command::ForceStart => {
+        //                         world.data.state = GameState::Running(RunningState::Run);
+        //                     }
+        //                     Command::PrepareKickoffBlue => {
+        //                         kicker_team = Some(TeamColor::Blue);
+        //                         if world.team_color == TeamColor::Blue {
+        //                             world.data.state = GameState::Stopped(StoppedState::PrepareKickoff);
+        //                         } else {
+        //                             world.data.state = GameState::Stopped(StoppedState::Stop);
+        //                         }
+        //                     }
+        //                     Command::PrepareKickoffYellow => {
+        //                         kicker_team = Some(TeamColor::Yellow);
+        //                         if world.team_color == TeamColor::Yellow {
+        //                             world.data.state = GameState::Stopped(StoppedState::PrepareKickoff);
+        //                         } else {
+        //                             world.data.state = GameState::Stopped(StoppedState::Stop);
+        //                         }
+        //                     }
+        //                     Command::PreparePenaltyBlue => {}
+        //                     Command::PreparePenaltyYellow => {}
+        //                     Command::NormalStart => {
+        //                         world.data.state = GameState::Running(RunningState::KickOff(kicker_team.unwrap_or(TeamColor::Blue))); // FIX THIS auto color under too
+        //                     }
+        //                     _ => {}
+        //                 }
+        //             }
+        //             StoppedState::PrepareKickoff => {
+        //                 if let Command::NormalStart = referee_command {
+        //                     world.data.state = GameState::Running(RunningState::KickOff(kicker_team.unwrap_or(TeamColor::Blue)));
+        //                 }
+        //             }
+        //             StoppedState::PreparePenalty => {
+        //                 if let Command::NormalStart = referee_command {
+        //                     world.data.state = GameState::Running(RunningState::KickOff(kicker_team.unwrap_or(TeamColor::Blue)));
+        //                 }
+        //             }
+        //             StoppedState::BallPlacement => {
+        //                 // TODO: what the fuck ?
+        //                 // if let Command::Continue {
+        //                 //     world.data.state = GameState::Running(RunningState::KickOff);
+        //                 // }
+        //             }
+        //         }
+        //     }
+        //     GameState::Running(running_state) => {
+        //         match running_state {
+        //             RunningState::KickOff(_) => {
+        //                 if let Some(ball) = &world.ball {
+        //                     if ball.velocity.xy().norm() > 0.3 {
+        //                         world.data.state = GameState::Running(RunningState::Run);
+        //                     }
+        //                 }
+        //                 if let Some(chrono) = &self.chrono {
+        //                     if chrono.elapsed() > std::time::Duration::from_secs(10) {
+        //                         world.data.state = GameState::Running(RunningState::Run);
+        //                     }
+        //                 } else {
+        //                     // start chrono
+        //                     self.chrono = Some(Instant::now());
+        //                 }
+        //                 // if let Command::AfterXSecondsOrIfBallMoved {
+        //                 //     world.data.state = GameState::Running(RunningState::Run);
+        //                 // }
+        //             }
+        //             RunningState::FreeKick => {
+        //                 // if let Command::AfterXSecondsOrIfBallMoved {
+        //                 //     world.data.state = GameState::Running(RunningState::Run);
+        //                 // }
+        //             }
+        //             _ => {}
+        //         }
+        //     }
+        // }
+        //
+        dbg!(referee_command);
+        dbg!(&world.data.state);
+    }
+}

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -207,7 +207,7 @@ impl GameControllerPostFilter {
             // [ALLEMAGNE] chrono check peut être enlevé si pas de ball placement auto
             if chrono.elapsed() >= std::time::Duration::from_secs(30) {
                 //TODO : when ball placement isn't done in 30 sec, what happen ?
-                world.data.state = GameState::Stopped(StoppedState::BallPlacement(team));
+                world.data.state = GameState::Stopped(StoppedState::BallPlacement(team.opposite()));
                 //world.data.state = GameState::Running(RunningState::Run);
             } else {
                 world.data.state = GameState::Stopped(StoppedState::BallPlacement(team));

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -95,11 +95,7 @@ impl GameControllerPostFilter {
         world: &mut World,
         mut chrono: Option<Instant>,
     ) {
-        GameControllerPostFilter::normal_start_state_branch(
-            previous_event_opt,
-            world,
-            chrono
-        )
+        GameControllerPostFilter::normal_start_state_branch(previous_event_opt, world, chrono)
     }
     fn normal_start_state_branch(
         previous_event_opt: &Option<Event>,
@@ -150,7 +146,6 @@ impl GameControllerPostFilter {
     fn timeout_blue_branch(world: &mut World) {
         world.data.state = GameState::Halted(HaltedState::Timeout);
     }
-
 
     fn freekick_blue_branch(world: &mut World, mut chrono_opt: Option<Instant>) {
         if let Some(chrono) = chrono_opt {
@@ -234,20 +229,45 @@ impl PostFilter for GameControllerPostFilter {
 
         match ref_command {
             Command::Halt => GameControllerPostFilter::halt_state_branch(world),
-            Command::Stop => GameControllerPostFilter::stop_state_branch(&self.previous_event,world,self.kicked_off_once),
-            Command::NormalStart => GameControllerPostFilter::normal_start_state_branch(&self.previous_event,world,self.chrono),
-            Command::ForceStart => GameControllerPostFilter::force_start_state_branch(&self.previous_event, world, self.chrono),
+            Command::Stop => GameControllerPostFilter::stop_state_branch(
+                &self.previous_event,
+                world,
+                self.kicked_off_once,
+            ),
+            Command::NormalStart => GameControllerPostFilter::normal_start_state_branch(
+                &self.previous_event,
+                world,
+                self.chrono,
+            ),
+            Command::ForceStart => GameControllerPostFilter::force_start_state_branch(
+                &self.previous_event,
+                world,
+                self.chrono,
+            ),
             Command::TimeoutYellow => GameControllerPostFilter::timeout_yellow_branch(world),
             Command::TimeoutBlue => GameControllerPostFilter::timeout_blue_branch(world),
-            Command::DirectFreeYellow => GameControllerPostFilter::freekick_yellow_branch(world, self.chrono),
-            Command::DirectFreeBlue => GameControllerPostFilter::freekick_blue_branch(world, self.chrono),
-            Command::BallPlacementYellow => GameControllerPostFilter::ball_placement_yellow_branch(world, self.chrono),
-            Command::BallPlacementBlue => GameControllerPostFilter::ball_placement_blue_branch(world, self.chrono),
-            Command::PreparePenaltyYellow => GameControllerPostFilter::prepare_penalty_yellow_branch(world, self.chrono),
-            Command::PreparePenaltyBlue => GameControllerPostFilter::prepare_penalty_blue_branch(world, self.chrono),
+            Command::DirectFreeYellow => {
+                GameControllerPostFilter::freekick_yellow_branch(world, self.chrono)
+            }
+            Command::DirectFreeBlue => {
+                GameControllerPostFilter::freekick_blue_branch(world, self.chrono)
+            }
+            Command::BallPlacementYellow => {
+                GameControllerPostFilter::ball_placement_yellow_branch(world, self.chrono)
+            }
+            Command::BallPlacementBlue => {
+                GameControllerPostFilter::ball_placement_blue_branch(world, self.chrono)
+            }
+            Command::PreparePenaltyYellow => {
+                GameControllerPostFilter::prepare_penalty_yellow_branch(world, self.chrono)
+            }
+            Command::PreparePenaltyBlue => {
+                GameControllerPostFilter::prepare_penalty_blue_branch(world, self.chrono)
+            }
             _ => {
                 println!("untreated state");
-                dbg!(ref_command);}
+                dbg!(ref_command);
+            }
         }
 
         // Update previous gamestate & event

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -216,8 +216,9 @@ impl GameControllerPostFilter {
         world.data.state = GameState::Stopped(StoppedState::PrepareKickoff(team));
     }
 
-    fn ball_placement_branch(world: &mut World, chrono_opt: Option<Instant>, team:TeamColor) {
-        if let Some(chrono) = chrono_opt {
+    fn ball_placement_branch(world: &mut World,game_controller: &mut GameControllerPostFilter, team:TeamColor) {
+        println!("Ball placement branch");
+        if let Some(chrono) = game_controller.chrono {
             // [ALLEMAGNE] chrono check peut être enlevé si pas de ball placement auto
             if chrono.elapsed() >= std::time::Duration::from_secs(30) {
                 world.data.state = GameState::Running(RunningState::Run);
@@ -225,8 +226,8 @@ impl GameControllerPostFilter {
                 world.data.state = GameState::Stopped(StoppedState::BallPlacement(team));
             }
         }
-        // The chrono should always be available to us
-        unreachable!(); // todo remove
+        //reseting the chrono
+        game_controller.fix_yourself();
     }
 }
 
@@ -263,7 +264,7 @@ impl PostFilter for GameControllerPostFilter {
                 GameControllerPostFilter::freekick_branch(world, self.chrono, team)
             }
             RefereeCommand::BallPlacement(team) => {
-                GameControllerPostFilter::ball_placement_branch(world, self.chrono, team)
+                GameControllerPostFilter::ball_placement_branch(world, self, team)
             }
             RefereeCommand::PreparePenalty(team) => {
                 GameControllerPostFilter::prepare_penalty_branch(world, self.chrono, team)

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -191,9 +191,7 @@ impl PostFilter for GameControllerPostFilter {
             Some(r) => r
         };
 
-        // Note de journal: 4h44
-        // - touche une pute :D
-        // dbg!(last_referee_packet);
+        println!("{:?}",last_referee_packet);
         let ref_command = last_referee_packet.command();
 
         // dbg!(&ref_command);

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -107,7 +107,7 @@ impl GameControllerPostFilter {
                 Event::UnsportingBehaviorMajor(_) |
                 Event::DeprecatedEvent => {
                     // TODO: the "world.team_color" isn't right
-                    world.data.state = GameState::Stopped(StoppedState::BallPlacement(world.team_color));
+                    world.data.state = GameState::Stopped(StoppedState::Stop);
                 }
             }
         } else {
@@ -122,7 +122,7 @@ impl GameControllerPostFilter {
         world: &mut World,
         mut _chrono: Option<Instant>,
     ) {
-        GameControllerPostFilter::normal_start_state_branch(previous_event_opt, previous_command, world, _chrono)
+        world.data.state = GameState::Running(RunningState::Run);
     }
 
     fn normal_start_state_branch(
@@ -206,7 +206,9 @@ impl GameControllerPostFilter {
         if let Some(chrono) = game_controller.chrono {
             // [ALLEMAGNE] chrono check peut être enlevé si pas de ball placement auto
             if chrono.elapsed() >= std::time::Duration::from_secs(30) {
-                world.data.state = GameState::Running(RunningState::Run);
+                //TODO : when ball placement isn't done in 30 sec, what happen ?
+                world.data.state = GameState::Stopped(StoppedState::BallPlacement(team));
+                //world.data.state = GameState::Running(RunningState::Run);
             } else {
                 world.data.state = GameState::Stopped(StoppedState::BallPlacement(team));
             }
@@ -228,7 +230,7 @@ impl PostFilter for GameControllerPostFilter {
         };
 
         let ref_command = last_referee_packet.command.clone();
-        //TODO : not sure about the indirect free kick refCommand 
+        //TODO : not sure about the indirect free refCommand
         match ref_command {
             RefereeCommand::Halt => GameControllerPostFilter::halt_state_branch(world),
             RefereeCommand::Deprecated |

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -56,26 +56,23 @@ impl GameControllerPostFilter {
         previous_command: &RefereeCommand,
         world: &mut World,
         _kicked_off_once: &mut bool,
+        mut _chrono: Option<Instant>,
     ) {
         // TODO: the "world.team_color" isn't right
         if let Some(previous_game_event) = previous_game_event_opt {
             let previous_event = &previous_game_event.event;
-            dbg!(previous_event);
             match previous_event {
                 // Goal has been scored, prepare for next kickoff phase
                 Event::Goal { .. } => {
                     world.data.state = GameState::Stopped(StoppedState::PrepareKickoff(world.team_color));
-                    println!("Prepare for kickoff");
                 }
 
                 Event::BallLeftFieldTouchLine { .. } => {
                     world.data.state = GameState::Stopped(StoppedState::BallPlacement(world.team_color));
-                    println!("Ball got out of the field by the touch lines !");
                 }
 
                 Event::BallLeftFieldGoalLine { .. } => {
                     world.data.state = GameState::Stopped(StoppedState::BallPlacement(world.team_color));
-                    println!("Ball got out of the field by the goal lines !");
                 }
                 //TODO : check if all these events have to be stopped
                 Event::AimlessKick(_) |
@@ -129,23 +126,44 @@ impl GameControllerPostFilter {
                 world.data.state = GameState::Stopped(StoppedState::Stop);
             }
         }
+        _chrono = Some(Instant::now());
     }
 
     fn force_start_state_branch(
         previous_event_opt: &Option<Event>,
+        previous_command: RefereeCommand,
         world: &mut World,
         mut _chrono: Option<Instant>,
     ) {
-        GameControllerPostFilter::normal_start_state_branch(previous_event_opt, world, _chrono)
+        GameControllerPostFilter::normal_start_state_branch(previous_event_opt, previous_command, world, _chrono)
     }
 
     fn normal_start_state_branch(
         previous_event_opt: &Option<Event>,
+        previous_command: RefereeCommand,
         world: &mut World,
         mut _chrono: Option<Instant>,
     ) {
         //TODO team color
-        if let Some(previous_event) = previous_event_opt {
+        if let Some(chrono) = _chrono {
+            if previous_command == RefereeCommand::PrepareKickoff(TeamColor::Blue){
+                if chrono.elapsed() >= std::time::Duration::from_secs(10) {
+                    world.data.state = GameState::Running(RunningState::Run);
+                } else {
+                    world.data.state = GameState::Running(RunningState::KickOff(TeamColor::Blue));
+                }
+                return
+            }
+            else if previous_command == RefereeCommand::PrepareKickoff(TeamColor::Yellow){
+                if chrono.elapsed() >= std::time::Duration::from_secs(10) {
+                    world.data.state = GameState::Running(RunningState::Run);
+                } else {
+                    world.data.state = GameState::Running(RunningState::KickOff(TeamColor::Yellow));
+                }
+                return
+            }
+        }
+        else if let Some(previous_event) = previous_event_opt {
             match previous_event {
                 Event::Goal(g) => {
                     // Kickoff is in progress by a team, place accordingly on your side
@@ -158,26 +176,17 @@ impl GameControllerPostFilter {
                             world.data.state =
                                 GameState::Running(RunningState::KickOff(g.by_team.opposite()));
                         }
+                        return
                     } else {
-                        println!("Running normally after kickoff");
                         // start chrono
                         _chrono = Some(Instant::now());
-                        world.data.state = GameState::Running(RunningState::Run);
                     }
                 }
 
-                &_ => {
-                    // Just play the game when no particular state is found (like penalty kick failed)
-                    // - what's your problem green ?
-                    // - me said alone ramp, me said alone ramp
-                    // - (proceeds to destroy his table)
-                    world.data.state = GameState::Running(RunningState::Run);
-                }
+                &_ => {}
             }
-        } else {
-            //println!("Play by default");
-            world.data.state = GameState::Running(RunningState::Run);
-        }
+        } 
+        world.data.state = GameState::Running(RunningState::Run);
     }
 
     fn timeout_branch(world: &mut World, _team:TeamColor) {
@@ -239,13 +248,13 @@ impl PostFilter for GameControllerPostFilter {
             RefereeCommand::Deprecated |
             RefereeCommand::IndirectFree(_) |
             RefereeCommand::Stop => {
-                GameControllerPostFilter::stop_state_branch(&self.previous_game_event, &self.previous_command, world, &mut self.kicked_off_once,)
+                GameControllerPostFilter::stop_state_branch(&self.previous_game_event, &self.previous_command, world, &mut self.kicked_off_once, self.chrono,)
             },
             RefereeCommand::NormalStart => {
-                GameControllerPostFilter::normal_start_state_branch(&self.previous_event, world, self.chrono,)
+                GameControllerPostFilter::normal_start_state_branch(&self.previous_event, self.previous_command.clone(), world, self.chrono,)
             },
             RefereeCommand::ForceStart => {
-                GameControllerPostFilter::force_start_state_branch(&self.previous_event, world, self.chrono,)
+                GameControllerPostFilter::force_start_state_branch(&self.previous_event, self.previous_command.clone(), world, self.chrono,)
             },
             RefereeCommand::Timeout(team) => {
                 GameControllerPostFilter::timeout_branch(world, team)
@@ -275,6 +284,7 @@ impl PostFilter for GameControllerPostFilter {
         }
         if ref_command != self.last_command{
             self.previous_command = self.last_command.clone();
+            self.chrono = Option::from(Instant::now());
         }
         self.last_command = ref_command.clone();
 

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -18,7 +18,7 @@ pub struct GameControllerPostFilter {
     previous_game_event: crabe_protocol::protobuf::game_controller_packet::GameEvent,
     // previous_event: Option<Event>,
     // chrono: Option<Instant>,
-    //#[serde(skip_serializing)]
+    #[serde(skip_serializing)]
     previous_event: Option<Event>,
     chrono: Option<Instant>,
     kicked_off_once: bool

--- a/crates/crabe_filter/src/pre_filter.rs
+++ b/crates/crabe_filter/src/pre_filter.rs
@@ -1,9 +1,27 @@
 use crate::data::FilterData;
+use chrono::{DateTime, LocalResult, TimeZone, Utc};
 use crabe_framework::data::input::InboundData;
 use crabe_framework::data::world::TeamColor;
+use log::error;
 
 pub mod game_controller;
 pub mod vision;
+
+pub fn create_date_time(time: f64) -> DateTime<Utc> {
+    match Utc.timestamp_opt((time) as i64, 0) {
+        LocalResult::Single(dt) => dt,
+        LocalResult::None => {
+            let now_utc = Utc::now();
+            error!("Invalid timestamp, using current time: {}", now_utc);
+            now_utc
+        }
+        LocalResult::Ambiguous(dt_min, dt_max) => {
+            let dt_midpoint = dt_min + (dt_max - dt_min) / 2;
+            error!("Ambiguous timestamp resolved to midpoint: {}", dt_midpoint);
+            dt_midpoint
+        }
+    }
+}
 
 pub trait PreFilter {
     fn step(

--- a/crates/crabe_filter/src/pre_filter.rs
+++ b/crates/crabe_filter/src/pre_filter.rs
@@ -3,6 +3,7 @@ use crabe_framework::data::input::InboundData;
 use crabe_framework::data::world::TeamColor;
 
 pub mod vision;
+pub mod game_controller;
 
 pub trait PreFilter {
     fn step(

--- a/crates/crabe_filter/src/pre_filter.rs
+++ b/crates/crabe_filter/src/pre_filter.rs
@@ -2,8 +2,8 @@ use crate::data::FilterData;
 use crabe_framework::data::input::InboundData;
 use crabe_framework::data::world::TeamColor;
 
-pub mod vision;
 pub mod game_controller;
+pub mod vision;
 
 pub trait PreFilter {
     fn step(

--- a/crates/crabe_filter/src/pre_filter.rs
+++ b/crates/crabe_filter/src/pre_filter.rs
@@ -9,7 +9,7 @@ pub mod vision;
 pub trait PreFilter {
     fn step(
         &mut self,
-        inbound_data: &InboundData,
+        inbound_data: &mut InboundData,
         team_color: &TeamColor,
         filter_data: &mut FilterData,
     );

--- a/crates/crabe_filter/src/pre_filter.rs
+++ b/crates/crabe_filter/src/pre_filter.rs
@@ -1,27 +1,10 @@
 use crate::data::FilterData;
-use chrono::{DateTime, LocalResult, TimeZone, Utc};
 use crabe_framework::data::input::InboundData;
 use crabe_framework::data::world::TeamColor;
-use log::error;
 
+pub mod common;
 pub mod game_controller;
 pub mod vision;
-
-pub fn create_date_time(time: f64) -> DateTime<Utc> {
-    match Utc.timestamp_opt((time) as i64, 0) {
-        LocalResult::Single(dt) => dt,
-        LocalResult::None => {
-            let now_utc = Utc::now();
-            error!("Invalid timestamp, using current time: {}", now_utc);
-            now_utc
-        }
-        LocalResult::Ambiguous(dt_min, dt_max) => {
-            let dt_midpoint = dt_min + (dt_max - dt_min) / 2;
-            error!("Ambiguous timestamp resolved to midpoint: {}", dt_midpoint);
-            dt_midpoint
-        }
-    }
-}
 
 pub trait PreFilter {
     fn step(

--- a/crates/crabe_filter/src/pre_filter/common.rs
+++ b/crates/crabe_filter/src/pre_filter/common.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, LocalResult, TimeZone, Utc};
 use log::error;
 
 pub fn create_date_time(t_capture: i64) -> DateTime<Utc> {
-    dbg!(t_capture);
+    //dbg!(t_capture);
     match Utc.timestamp_opt(t_capture, 0) {
         LocalResult::Single(dt) => dt,
         LocalResult::None => {

--- a/crates/crabe_filter/src/pre_filter/common.rs
+++ b/crates/crabe_filter/src/pre_filter/common.rs
@@ -1,0 +1,19 @@
+use chrono::{DateTime, LocalResult, TimeZone, Utc};
+use log::error;
+
+pub fn create_date_time(t_capture: i64) -> DateTime<Utc> {
+    dbg!(t_capture);
+    match Utc.timestamp_opt(t_capture, 0) {
+        LocalResult::Single(dt) => dt,
+        LocalResult::None => {
+            let now_utc = Utc::now();
+            error!("Invalid timestamp, using current time: {}", now_utc);
+            now_utc
+        }
+        LocalResult::Ambiguous(dt_min, dt_max) => {
+            let dt_midpoint = dt_min + (dt_max - dt_min) / 2;
+            error!("Ambiguous timestamp resolved to midpoint: {}", dt_midpoint);
+            dt_midpoint
+        }
+    }
+}

--- a/crates/crabe_filter/src/pre_filter/game_controller.rs
+++ b/crates/crabe_filter/src/pre_filter/game_controller.rs
@@ -5,11 +5,7 @@ use crabe_framework::data::world::TeamColor;
 
 pub struct GameControllerPreFilter;
 
-impl GameControllerPreFilter {
-    fn new() -> Self {
-        Self
-    }
-}
+impl GameControllerPreFilter {}
 
 impl PreFilter for GameControllerPreFilter {
     fn step(

--- a/crates/crabe_filter/src/pre_filter/game_controller.rs
+++ b/crates/crabe_filter/src/pre_filter/game_controller.rs
@@ -176,9 +176,9 @@ fn map_ball_left_field(value: protocol_event::BallLeftField) -> BallLeftField {
 }
 
 fn map_game_event(game_event: ProtocolEvent) -> Option<GameEvent> {
+    println!("test game");
     let created_timestamp = game_event.created_timestamp;
     let event = game_event.event.map(map_event).flatten();
-    println!("test game");
     for ele in game_event.origin {
         println!("{}",ele);
     }
@@ -448,6 +448,7 @@ fn map_protobuf_referee(
         TeamColor::Yellow => (packet.yellow, packet.blue),
         TeamColor::Blue => (packet.blue, packet.yellow),
     };
+    println!("cascre2 : {:?}",packet.game_events);
 
     Ok(Referee {
         source_identifier: packet.source_identifier,
@@ -488,6 +489,7 @@ fn map_protobuf_referee(
             .current_action_time_remaining
             .map(|d| Duration::microseconds(d as i64)),
     })
+    
     // Ok(Referee {})
 }
 

--- a/crates/crabe_filter/src/pre_filter/game_controller.rs
+++ b/crates/crabe_filter/src/pre_filter/game_controller.rs
@@ -135,8 +135,8 @@ fn convert_referee_protobuf(packet: &game_controller_packet::Referee, team_color
             Some(command) => Some(get_command(command)),
             None => None
         },
-        game_events: todo!(),
-        game_event_proposals: todo!(),
+        game_events: vec![],
+        game_event_proposals: vec![],
         current_action_time_remaining: match packet.current_action_time_remaining {
             Some(duration_value) => Some(Duration::seconds(duration_value as i64)),
             None => Some(Duration::zero())

--- a/crates/crabe_filter/src/pre_filter/game_controller.rs
+++ b/crates/crabe_filter/src/pre_filter/game_controller.rs
@@ -10,9 +10,9 @@ use nalgebra::Point2;
 use crabe_protocol::protobuf::game_controller_packet::game_event as protocol_event;
 use crabe_protocol::protobuf::game_controller_packet::game_event::{Event as ProtocolEventData, Goal as ProtocolGoal};
 
-use crabe_protocol::protobuf::game_controller_packet::{GameEvent as ProtocolEvent, MatchType as ProtocolMatchType, Referee as ProtocolReferee, Vector2 as ProtocolVector2};
+use crabe_protocol::protobuf::game_controller_packet::{GameEvent as ProtocolEvent, game_event::Type as ProtocolType, MatchType as ProtocolMatchType, Referee as ProtocolReferee, Vector2 as ProtocolVector2};
 use crabe_protocol::protobuf::game_controller_packet::referee::{Command as ProtocolCommand, Command, Point as ProtocolPoint, Stage as ProtocolStage};
-use crate::data::referee::event::{Event, AimlessKick, AttackerDoubleTouchedBall, AttackerTooCloseToDefenseArea, AttackerTouchedBallInDefenseArea, BallLeftField, BotCrashDrawn, BotCrashUnique, BotDribbledBallTooFar, BotHeldBallDeliberately, BotInterferedPlacement, BotKickedBallTooFast, BotPushedBot, BotTippedOver, BotTooFastInStop, BoundaryCrossing, DefenderInDefenseArea, DefenderTooCloseToKickPoint, GameEvent, Goal, KeeperHeldBall, MultipleFouls, NoProgressInGame, PenaltyKickFailed, PlacementFailed, PlacementSucceeded, TooManyRobots, UnsportingBehavior};
+use crate::data::referee::event::{Event, AimlessKick, AttackerDoubleTouchedBall, AttackerTooCloseToDefenseArea, AttackerTouchedBallInDefenseArea, BallLeftField, BotCrashDrawn, BotCrashUnique, BotDribbledBallTooFar, BotHeldBallDeliberately, BotInterferedPlacement, BotKickedBallTooFast, BotPushedBot, BotTippedOver, BotTooFastInStop, BoundaryCrossing, DefenderInDefenseArea, DefenderTooCloseToKickPoint, GameEvent, Goal, KeeperHeldBall, MultipleFouls, NoProgressInGame, PenaltyKickFailed, PlacementFailed, PlacementSucceeded, TooManyRobots, UnsportingBehaviorMajor, UnsportingBehaviorMinor, GameEventType};
 
 use crate::data::referee::{GameEventProposalGroup, Referee, RefereeCommand, Stage, TeamInfo};
 use crabe_protocol::protobuf::game_controller_packet::Team as ProtocolTeam;
@@ -116,6 +116,57 @@ fn map_goal(goal: ProtocolGoal) -> Goal {
     }
 }
 
+fn map_type(event_type: ProtocolType) -> GameEventType{
+    match event_type {
+        ProtocolType::BallLeftFieldTouchLine=>GameEventType::BallLeftFieldTouchLine,
+        ProtocolType::BallLeftFieldGoalLine=>GameEventType::BallLeftFieldGoalLine,
+        ProtocolType::AimlessKick=>GameEventType::AimlessKick,
+        ProtocolType::AttackerTooCloseToDefenseArea=>GameEventType::AttackerTooCloseToDefenseArea,
+        ProtocolType::DefenderInDefenseArea=>GameEventType::DefenderInDefenseArea,
+        ProtocolType::BoundaryCrossing=>GameEventType::BoundaryCrossing,
+        ProtocolType::KeeperHeldBall=>GameEventType::KeeperHeldBall,
+        ProtocolType::BotDribbledBallTooFar=>GameEventType::BotDribbledBallTooFar,
+        ProtocolType::BotPushedBot=>GameEventType::BotPushedBot,
+        ProtocolType::BotHeldBallDeliberately=>GameEventType::BotHeldBallDeliberately,
+        ProtocolType::BotTippedOver=>GameEventType::BotTippedOver,
+        ProtocolType::AttackerTouchedBallInDefenseArea=>GameEventType::AttackerTouchedBallInDefenseArea,
+        ProtocolType::BotKickedBallTooFast=>GameEventType::BotKickedBallTooFast,
+        ProtocolType::BotCrashUnique=>GameEventType::BotCrashUnique,
+        ProtocolType::BotCrashDrawn=>GameEventType::BotCrashDrawn,
+        ProtocolType::DefenderTooCloseToKickPoint=>GameEventType::DefenderTooCloseToKickPoint,
+        ProtocolType::BotTooFastInStop=>GameEventType::BotTooFastInStop,
+        ProtocolType::BotInterferedPlacement=>GameEventType::BotInterferedPlacement,
+        ProtocolType::PossibleGoal=>GameEventType::PossibleGoal,
+        ProtocolType::Goal=>GameEventType::Goal,
+        ProtocolType::InvalidGoal=>GameEventType::InvalidGoal,
+        ProtocolType::AttackerDoubleTouchedBall=>GameEventType::AttackerDoubleTouchedBall,
+        ProtocolType::PlacementSucceeded=>GameEventType::PlacementSucceeded,
+        ProtocolType::PenaltyKickFailed=>GameEventType::PenaltyKickFailed,
+        ProtocolType::NoProgressInGame=>GameEventType::NoProgressInGame,
+        ProtocolType::PlacementFailed=>GameEventType::PlacementFailed,
+        ProtocolType::MultipleCards=>GameEventType::MultipleCards,
+        ProtocolType::MultipleFouls=>GameEventType::MultipleFouls,
+        ProtocolType::BotSubstitution=>GameEventType::BotSubstitution,
+        ProtocolType::TooManyRobots=>GameEventType::TooManyRobots,
+        ProtocolType::ChallengeFlag=>GameEventType::ChallengeFlag,
+        ProtocolType::ChallengeFlagHandled=>GameEventType::ChallengeFlagHandled,
+        ProtocolType::EmergencyStop=>GameEventType::EmergencyStop,
+        ProtocolType::UnsportingBehaviorMinor=>GameEventType::UnsportingBehaviorMinor,
+        ProtocolType::UnsportingBehaviorMajor=>GameEventType::UnsportingBehaviorMajor,
+        ProtocolType::UnknownGameEventType => todo!(),
+        ProtocolType::Prepared => todo!(),
+        ProtocolType::IndirectGoal => todo!(),
+        ProtocolType::ChippedGoal => todo!(),
+        ProtocolType::KickTimeout => todo!(),
+        ProtocolType::AttackerTouchedOpponentInDefenseArea => todo!(),
+        ProtocolType::AttackerTouchedOpponentInDefenseAreaSkipped => todo!(),
+        ProtocolType::BotCrashUniqueSkipped => todo!(),
+        ProtocolType::BotPushedBotSkipped => todo!(),
+        ProtocolType::DefenderInDefenseAreaPartially => todo!(),
+        ProtocolType::MultiplePlacementFailures => todo!(),
+    }
+}
+
 fn map_ball_left_field(value: protocol_event::BallLeftField) -> BallLeftField {
     BallLeftField {
         by_team: map_team_color_i32(value.by_team),
@@ -123,18 +174,34 @@ fn map_ball_left_field(value: protocol_event::BallLeftField) -> BallLeftField {
         location: value.location.map(map_vector_point),
     }
 }
+fn map_game_event(game_event: ProtocolEvent) -> Option<GameEvent> {
+    return if let Some(event) = map_event(game_event) {
+        Some(GameEvent{
+            type_event: match game_event.r#type{
+                Some(r#type) => ProtocolType::from_i32(r#type)
+                    .map(map_type),
+                None => None
+            },
+            created_timestamp:game_event.created_timestamp,
+            origin:todo!(),
+            event,
+        })
+    }else{
+        None
+    };
+}
 
-fn map_event(event: ProtocolEvent) -> Option<GameEvent> {
+fn map_event(event: ProtocolEvent) -> Option<Event> {
     return if let Some(event) = event.event {
         match event {
             ProtocolEventData::BallLeftFieldTouchLine(data) => {
-                Some(GameEvent::BallLeftFieldTouchLine(map_ball_left_field(data)))
+                Some(Event::BallLeftFieldTouchLine(map_ball_left_field(data)))
             }
             ProtocolEventData::BallLeftFieldGoalLine(data) => {
-                Some(GameEvent::BallLeftFieldTouchLine(map_ball_left_field(data)))
+                Some(Event::BallLeftFieldTouchLine(map_ball_left_field(data)))
             }
             ProtocolEventData::AimlessKick(data) => {
-                Some(GameEvent::AimlessKick(AimlessKick {
+                Some(Event::AimlessKick(AimlessKick {
                     by_team: map_team_color_i32(data.by_team),
                     by_bot: data.by_bot,
                     location: data.location.map(map_vector_point),
@@ -142,7 +209,7 @@ fn map_event(event: ProtocolEvent) -> Option<GameEvent> {
                 }))
             }
             ProtocolEventData::AttackerTooCloseToDefenseArea(data) => {
-                Some(GameEvent::AttackerTooCloseToDefenseArea(AttackerTooCloseToDefenseArea {
+                Some(Event::AttackerTooCloseToDefenseArea(AttackerTooCloseToDefenseArea {
                     by_team: map_team_color_i32(data.by_team),
                     by_bot: data.by_bot,
                     location: data.location.map(map_vector_point),
@@ -151,7 +218,7 @@ fn map_event(event: ProtocolEvent) -> Option<GameEvent> {
                 }))
             }
             ProtocolEventData::DefenderInDefenseArea(data) => {
-                Some(GameEvent::DefenderInDefenseArea(DefenderInDefenseArea {
+                Some(Event::DefenderInDefenseArea(DefenderInDefenseArea {
                     by_team: map_team_color_i32(data.by_team),
                     by_bot: data.by_bot,
                     location: data.location.map(map_vector_point),
@@ -159,20 +226,20 @@ fn map_event(event: ProtocolEvent) -> Option<GameEvent> {
                 }))
             }
             ProtocolEventData::BoundaryCrossing(data) => {
-                Some(GameEvent::BoundaryCrossing(BoundaryCrossing {
+                Some(Event::BoundaryCrossing(BoundaryCrossing {
                     by_team: map_team_color_i32(data.by_team),
                     location: data.location.map(map_vector_point),
                 }))
             }
             ProtocolEventData::KeeperHeldBall(data) => {
-                Some(GameEvent::KeeperHeldBall(KeeperHeldBall {
+                Some(Event::KeeperHeldBall(KeeperHeldBall {
                     by_team: map_team_color_i32(data.by_team),
                     location: data.location.map(map_vector_point),
                     duration: data.duration.map(|d| Duration::seconds(d as i64)), // TODO: More precision?
                 }))
             }
             ProtocolEventData::BotDribbledBallTooFar(data) => {
-                Some(GameEvent::BotDribbledBallTooFar(BotDribbledBallTooFar {
+                Some(Event::BotDribbledBallTooFar(BotDribbledBallTooFar {
                     by_team: map_team_color_i32(data.by_team),
                     by_bot: data.by_bot,
                     start: data.start.map(map_vector_point),
@@ -180,7 +247,7 @@ fn map_event(event: ProtocolEvent) -> Option<GameEvent> {
                 }))
             }
             ProtocolEventData::BotPushedBot(data) => {
-                Some(GameEvent::BotPushedBot(BotPushedBot {
+                Some(Event::BotPushedBot(BotPushedBot {
                     by_team: map_team_color_i32(data.by_team),
                     violator: data.violator,
                     victim: data.victim,
@@ -189,7 +256,7 @@ fn map_event(event: ProtocolEvent) -> Option<GameEvent> {
                 }))
             }
             ProtocolEventData::BotHeldBallDeliberately(data) => {
-                Some(GameEvent::BotHeldBallDeliberately(BotHeldBallDeliberately {
+                Some(Event::BotHeldBallDeliberately(BotHeldBallDeliberately {
                     by_team: map_team_color_i32(data.by_team),
                     by_bot: data.by_bot,
                     location: data.location.map(map_vector_point),
@@ -197,7 +264,7 @@ fn map_event(event: ProtocolEvent) -> Option<GameEvent> {
                 }))
             }
             ProtocolEventData::BotTippedOver(data) => {
-                Some(GameEvent::BotTippedOver(BotTippedOver {
+                Some(Event::BotTippedOver(BotTippedOver {
                     by_team: map_team_color_i32(data.by_team),
                     by_bot: data.by_bot,
                     location: data.location.map(map_vector_point),
@@ -205,7 +272,7 @@ fn map_event(event: ProtocolEvent) -> Option<GameEvent> {
                 }))
             }
             ProtocolEventData::AttackerTouchedBallInDefenseArea(data) => {
-                Some(GameEvent::AttackerTouchedBallInDefenseArea(AttackerTouchedBallInDefenseArea {
+                Some(Event::AttackerTouchedBallInDefenseArea(AttackerTouchedBallInDefenseArea {
                     by_team: map_team_color_i32(data.by_team),
                     by_bot: data.by_bot,
                     location: data.location.map(map_vector_point),
@@ -213,7 +280,7 @@ fn map_event(event: ProtocolEvent) -> Option<GameEvent> {
                 }))
             }
             ProtocolEventData::BotKickedBallTooFast(data) => {
-                Some(GameEvent::BotKickedBallTooFast(BotKickedBallTooFast {
+                Some(Event::BotKickedBallTooFast(BotKickedBallTooFast {
                     by_team: map_team_color_i32(data.by_team),
                     by_bot: data.by_bot,
                     location: data.location.map(map_vector_point),
@@ -222,7 +289,7 @@ fn map_event(event: ProtocolEvent) -> Option<GameEvent> {
                 }))
             }
             ProtocolEventData::BotCrashUnique(data) => {
-                Some(GameEvent::BotCrashUnique(BotCrashUnique {
+                Some(Event::BotCrashUnique(BotCrashUnique {
                     by_team: map_team_color_i32(data.by_team),
                     violator: data.violator,
                     victim: data.victim,
@@ -233,16 +300,17 @@ fn map_event(event: ProtocolEvent) -> Option<GameEvent> {
                 }))
             }
             ProtocolEventData::BotCrashDrawn(data) => {
-                Some(GameEvent::BotCrashDrawn(BotCrashDrawn {
+                Some(Event::BotCrashDrawn(BotCrashDrawn {
                     bot_blue: data.bot_blue,
                     bot_yellow: data.bot_yellow,
                     crash_speed: data.crash_speed.map(|s| s as f64),
                     speed_diff: data.speed_diff.map(|d| d as f64),
                     crash_angle: data.crash_angle.map(|a| a as f64),
+                    location: todo!(),
                 }))
             }
             ProtocolEventData::BotTooFastInStop(data) => {
-                Some(GameEvent::BotTooFastInStop(BotTooFastInStop {
+                Some(Event::BotTooFastInStop(BotTooFastInStop {
                     by_team: map_team_color_i32(data.by_team),
                     by_bot: data.by_bot,
                     location: data.location.map(map_vector_point),
@@ -250,68 +318,69 @@ fn map_event(event: ProtocolEvent) -> Option<GameEvent> {
                 }))
             }
             ProtocolEventData::BotInterferedPlacement(data) => {
-                Some(GameEvent::BotInterferedPlacement(BotInterferedPlacement {
+                Some(Event::BotInterferedPlacement(BotInterferedPlacement {
                     by_team: map_team_color_i32(data.by_team),
                     by_bot: data.by_bot,
                     location: data.location.map(map_vector_point),
                 }))
             }
             ProtocolEventData::PossibleGoal(data) => {
-                Some(GameEvent::PossibleGoal(map_goal(data)))
+                Some(Event::PossibleGoal(map_goal(data)))
             }
             ProtocolEventData::Goal(data) => {
-                Some(GameEvent::Goal(map_goal(data)))
+                Some(Event::Goal(map_goal(data)))
             }
             ProtocolEventData::InvalidGoal(data) => {
-                Some(GameEvent::InvalidGoal(map_goal(data)))
+                Some(Event::InvalidGoal(map_goal(data)))
             }
             ProtocolEventData::AttackerDoubleTouchedBall(data) => {
-                Some(GameEvent::AttackerDoubleTouchedBall(AttackerDoubleTouchedBall {
+                Some(Event::AttackerDoubleTouchedBall(AttackerDoubleTouchedBall {
                     by_team: map_team_color_i32(data.by_team),
                     by_bot: data.by_bot,
                     location: data.location.map(map_vector_point),
                 }))
             }
             ProtocolEventData::PlacementSucceeded(data) => {
-                Some(GameEvent::PlacementSucceeded(PlacementSucceeded {
+                Some(Event::PlacementSucceeded(PlacementSucceeded {
                     by_team: map_team_color_i32(data.by_team),
-                    time_taken: data.time_taken.map(|d| Duration::seconds(d as i64)),
+                    time_taken: data.time_taken.map(|d| d as f64),
                     precision: data.precision.map(|p| p as f64),
                     distance: data.distance.map(|d| d as f64),
                 }))
             }
             ProtocolEventData::PlacementFailed(data) => {
-                Some(GameEvent::PlacementFailed(PlacementFailed {
+                Some(Event::PlacementFailed(PlacementFailed {
                     by_team: map_team_color_i32(data.by_team),
                     remaining_distance: data.remaining_distance.map(|d| d as f64),
                 }))
             }
             ProtocolEventData::PenaltyKickFailed(data) => {
-                Some(GameEvent::PenaltyKickFailed(PenaltyKickFailed {
+                Some(Event::PenaltyKickFailed(PenaltyKickFailed {
                     by_team: map_team_color_i32(data.by_team),
                     location: data.location.map(map_vector_point),
+                    reason: todo!(),
                 }))
             }
             ProtocolEventData::NoProgressInGame(data) => {
-                Some(GameEvent::NoProgressInGame(NoProgressInGame {
+                Some(Event::NoProgressInGame(NoProgressInGame {
                     location: data.location.map(map_vector_point),
                     time: data.time.map(|d| Duration::seconds(d as i64)),
                 }))
             }
             ProtocolEventData::MultipleCards(data) => {
-                Some(GameEvent::MultipleCards(map_team_color_i32(data.by_team)))
+                Some(Event::MultipleCards(map_team_color_i32(data.by_team)))
             }
             ProtocolEventData::MultipleFouls(data) => {
-                Some(GameEvent::MultipleFouls(MultipleFouls {
+                Some(Event::MultipleFouls(MultipleFouls {
                     by_team: map_team_color_i32(data.by_team),
                     caused_game_events: vec![], // TODO
                 }))
             }
             ProtocolEventData::BotSubstitution(data) => {
-                Some(GameEvent::BotSubstitution(map_team_color_i32(data.by_team)))
+                Some(Event::BotSubstitution(map_team_color_i32(data.by_team)))
             }
             ProtocolEventData::TooManyRobots(data) => {
-                Some(GameEvent::TooManyRobots(TooManyRobots {
+                Some(Event::TooManyRobots(TooManyRobots {
                     by_team: map_team_color_i32(data.by_team),
                     num_robots_allowed: data.num_robots_allowed.map(|n| if n < 0 { 0 } else { n as u32 }),
                     num_robots_on_field: data.num_robots_on_field.map(|n| if n < 0 { 0 } else { n as u32 }),
@@ -319,25 +388,25 @@ fn map_event(event: ProtocolEvent) -> Option<GameEvent> {
                 }))
             }
             ProtocolEventData::ChallengeFlag(data) => {
-                Some(GameEvent::ChallengeFlag(map_team_color_i32(data.by_team)))
+                Some(Event::ChallengeFlag(map_team_color_i32(data.by_team)))
             }
             ProtocolEventData::EmergencyStop(data) => {
-                Some(GameEvent::EmergencyStop(map_team_color_i32(data.by_team)))
+                Some(Event::EmergencyStop(map_team_color_i32(data.by_team)))
             }
             ProtocolEventData::UnsportingBehaviorMinor(data) => {
-                Some(GameEvent::UnsportingBehaviorMinor(UnsportingBehavior {
+                Some(Event::UnsportingBehaviorMinor(UnsportingBehaviorMinor {
                     by_team: map_team_color_i32(data.by_team),
                     reason: data.reason,
                 }))
             }
             ProtocolEventData::UnsportingBehaviorMajor(data) => {
-                Some(GameEvent::UnsportingBehaviorMajor(UnsportingBehavior {
+                Some(Event::UnsportingBehaviorMajor(UnsportingBehaviorMajor {
                     by_team: map_team_color_i32(data.by_team),
                     reason: data.reason,
                 }))
             }
             ProtocolEventData::DefenderTooCloseToKickPoint(data) => {
-                Some(GameEvent::DefenderTooCloseToKickPoint(DefenderTooCloseToKickPoint {
+                Some(Event::DefenderTooCloseToKickPoint(DefenderTooCloseToKickPoint {
                     by_team: map_team_color_i32(data.by_team),
                     by_bot: data.by_bot,
                     location: data.location.map(map_vector_point),
@@ -406,9 +475,9 @@ fn map_protobuf_referee(
             .map(|c| ProtocolCommand::from_i32(c))
             .flatten()
             .map(map_command),
-        game_events: packet.game_events.drain(..).filter_map(map_event).collect(),
+        game_events: packet.game_events.drain(..).filter_map(map_game_event).collect(),
         game_event_proposals: packet.game_event_proposals.drain(..).map(|mut p| GameEventProposalGroup {
-            game_event: p.game_event.drain(..).filter_map(map_event).collect(),
+            game_event: p.game_event.drain(..).filter_map(map_game_event).collect(),
             accepted: p.accepted,
         }).collect(),
         current_action_time_remaining: packet

--- a/crates/crabe_filter/src/pre_filter/game_controller.rs
+++ b/crates/crabe_filter/src/pre_filter/game_controller.rs
@@ -1,11 +1,35 @@
 use crate::data::FilterData;
+use crate::data::referee::Referee;
 use crate::pre_filter::PreFilter;
 use crabe_framework::data::input::InboundData;
 use crabe_framework::data::world::TeamColor;
+use crabe_protocol::protobuf::game_controller_packet::{self, referee};
 
 pub struct GameControllerPreFilter;
 
 impl GameControllerPreFilter {}
+
+fn convert_referee_protobuf(packet: &game_controller_packet::Referee) -> Referee {
+    let referee = Referee {
+        source_identifier: todo!(),
+        match_type: todo!(),
+        packet_timestamp: todo!(),
+        stage: todo!(),
+        stage_time_left: todo!(),
+        command: todo!(),
+        command_counter: todo!(),
+        command_timestamp: todo!(),
+        ally: todo!(),
+        enemy: todo!(),
+        designated_position: todo!(),
+        positive_half: todo!(),
+        next_command: todo!(),
+        game_events: todo!(),
+        game_event_proposals: todo!(),
+        current_action_time_remaining: todo!(),
+    };
+    referee
+}
 
 impl PreFilter for GameControllerPreFilter {
     fn step(
@@ -14,6 +38,9 @@ impl PreFilter for GameControllerPreFilter {
         _team_color: &TeamColor,
         filter_data: &mut FilterData,
     ) {
+        inbound_data.gc_packet.iter().for_each(|gc_packet|{
+            convert_referee_protobuf(gc_packet);
+        });
         // TODO: The referee message needs to be inside our own framework.
 
         /*filter_data

--- a/crates/crabe_filter/src/pre_filter/game_controller.rs
+++ b/crates/crabe_filter/src/pre_filter/game_controller.rs
@@ -455,7 +455,7 @@ fn map_protobuf_referee(
         TeamColor::Yellow => (packet.yellow, packet.blue),
         TeamColor::Blue => (packet.blue, packet.yellow),
     };
-    println!("cascre2 : {:?}",packet.game_events);
+    //println!("packet events : {:?}",packet.game_events);
 
     Ok(Referee {
         source_identifier: packet.source_identifier,
@@ -507,7 +507,7 @@ impl PreFilter for GameControllerPreFilter {
         team_color: &TeamColor,
         filter_data: &mut FilterData,
     ) {
-        println!("len: {}", inbound_data.gc_packet.len());
+        //println!("len: {}", inbound_data.gc_packet.len());
         filter_data.referee.extend(
             inbound_data
                 .gc_packet

--- a/crates/crabe_filter/src/pre_filter/game_controller.rs
+++ b/crates/crabe_filter/src/pre_filter/game_controller.rs
@@ -1,3 +1,4 @@
+use crate::data::referee::event::GameEvent;
 use crate::data::referee::{MatchType, Referee, RefereeCommand, Stage, TeamInfo};
 use crate::data::FilterData;
 use crate::pre_filter::{create_date_time, PreFilter};
@@ -60,7 +61,7 @@ fn convert_referee_protobuf(
     packet: &game_controller_packet::Referee,
     team_color: &TeamColor,
 ) -> Referee {
-    dbg!(packet);
+    // dbg!(packet);
     let ally = match team_color {
         TeamColor::Yellow => to_team_infos(&packet.yellow),
         TeamColor::Blue => to_team_infos(&packet.blue),
@@ -136,6 +137,11 @@ fn convert_referee_protobuf(
             None => Some(Duration::zero()),
         },
     };
+
+    packet.game_events.iter().for_each(|event| {
+        dbg!(GameEvent::from(event.clone()));
+    });
+
     _referee
 }
 

--- a/crates/crabe_filter/src/pre_filter/game_controller.rs
+++ b/crates/crabe_filter/src/pre_filter/game_controller.rs
@@ -1,0 +1,25 @@
+use crabe_framework::data::input::InboundData;
+use crabe_framework::data::world::TeamColor;
+use crate::data::FilterData;
+use crate::pre_filter::PreFilter;
+
+pub struct GameControllerPreFilter;
+
+impl GameControllerPreFilter {
+    fn new() -> Self {
+        Self
+    }
+}
+
+impl PreFilter for GameControllerPreFilter {
+    fn step(
+        &mut self,
+        inbound_data: &InboundData,
+        _team_color: &TeamColor,
+        filter_data: &mut FilterData,
+    ) {
+        // TODO: this allocates a ton
+        // dbg!(&inbound_data.gc_packet);
+        filter_data.referee.extend(inbound_data.gc_packet.iter().map(|p| p.clone()));
+    }
+}

--- a/crates/crabe_filter/src/pre_filter/game_controller.rs
+++ b/crates/crabe_filter/src/pre_filter/game_controller.rs
@@ -190,7 +190,7 @@ fn map_game_event(game_event: ProtocolEvent) -> Option<GameEvent> {
             },
             created_timestamp,
             event,
-            origin:vec![],
+            origin:vec![],//TODO
         })
     }else{
         None
@@ -497,7 +497,7 @@ impl PreFilter for GameControllerPreFilter {
         team_color: &TeamColor,
         filter_data: &mut FilterData,
     ) {
-        println!("tetete");
+        println!("len: {}", inbound_data.gc_packet.len());
         filter_data.referee.extend(
             inbound_data
                 .gc_packet

--- a/crates/crabe_filter/src/pre_filter/game_controller.rs
+++ b/crates/crabe_filter/src/pre_filter/game_controller.rs
@@ -455,8 +455,6 @@ fn map_protobuf_referee(
         TeamColor::Yellow => (packet.yellow, packet.blue),
         TeamColor::Blue => (packet.blue, packet.yellow),
     };
-    //println!("packet events : {:?}",packet.game_events);
-
     Ok(Referee {
         source_identifier: packet.source_identifier,
         match_type: None, // TODO : Finish

--- a/crates/crabe_filter/src/pre_filter/game_controller.rs
+++ b/crates/crabe_filter/src/pre_filter/game_controller.rs
@@ -174,6 +174,7 @@ fn map_ball_left_field(value: protocol_event::BallLeftField) -> BallLeftField {
         location: value.location.map(map_vector_point),
     }
 }
+
 fn map_game_event(game_event: ProtocolEvent) -> Option<GameEvent> {
     let created_timestamp = game_event.created_timestamp;
     let event = game_event.event.map(map_event).flatten();

--- a/crates/crabe_filter/src/pre_filter/game_controller.rs
+++ b/crates/crabe_filter/src/pre_filter/game_controller.rs
@@ -1,11 +1,13 @@
 use crate::data::referee::event::GameEvent;
 use crate::data::referee::{MatchType, Referee, RefereeCommand, Stage, TeamInfo};
 use crate::data::FilterData;
-use crate::pre_filter::{create_date_time, PreFilter};
+use crate::pre_filter::common::create_date_time;
+use crate::pre_filter::PreFilter;
 use chrono::Duration;
 use crabe_framework::data::input::InboundData;
 use crabe_framework::data::world::TeamColor;
 use crabe_protocol::protobuf::game_controller_packet;
+use log::{info, log};
 use nalgebra::Point2;
 
 pub struct GameControllerPreFilter;
@@ -81,7 +83,7 @@ fn convert_referee_protobuf(
             },
             None => None,
         },
-        packet_timestamp: create_date_time(packet.packet_timestamp as f64),
+        packet_timestamp: create_date_time((packet.packet_timestamp / 1_000_000) as i64),
         stage: match packet.stage {
             stage => match stage {
                 0 => Stage::NormalFirstHalfPre,
@@ -107,7 +109,7 @@ fn convert_referee_protobuf(
         },
         command: get_command(packet.command),
         command_counter: packet.command_counter,
-        command_timestamp: create_date_time(packet.command_timestamp as f64),
+        command_timestamp: create_date_time(packet.command_timestamp as i64),
         ally,
         enemy,
         designated_position: match &packet.designated_position {

--- a/crates/crabe_filter/src/pre_filter/game_controller.rs
+++ b/crates/crabe_filter/src/pre_filter/game_controller.rs
@@ -14,9 +14,10 @@ impl PreFilter for GameControllerPreFilter {
         _team_color: &TeamColor,
         filter_data: &mut FilterData,
     ) {
-        /// TODO: The referee message needs to be inside our own framework.
-        filter_data
-            .referee
-            .extend(inbound_data.gc_packet.iter().cloned());
+        // TODO: The referee message needs to be inside our own framework.
+
+        /*filter_data
+        .referee
+        .extend(inbound_data.gc_packet.iter().cloned());*/
     }
 }

--- a/crates/crabe_filter/src/pre_filter/game_controller.rs
+++ b/crates/crabe_filter/src/pre_filter/game_controller.rs
@@ -1,10 +1,10 @@
+use crate::data::referee::{MatchType, Referee, RefereeCommand, Stage, TeamInfo};
 use crate::data::FilterData;
-use crate::data::referee::{Referee, MatchType, Stage, RefereeCommand, TeamInfo};
 use crate::pre_filter::PreFilter;
+use chrono::{DateTime, Duration, NaiveDateTime, Utc};
 use crabe_framework::data::input::InboundData;
 use crabe_framework::data::world::TeamColor;
 use crabe_protocol::protobuf::game_controller_packet;
-use chrono::{DateTime, NaiveDateTime, Utc, Duration};
 use nalgebra::Point2;
 
 pub struct GameControllerPreFilter;
@@ -16,39 +16,37 @@ fn convert_timestamp_to_datetime(timestamp: u64) -> DateTime<Utc> {
     let datetime = DateTime::from_utc(naive_datetime, Utc);
     datetime
 }
-fn get_command(command: i32) -> RefereeCommand{
+fn get_command(command: i32) -> RefereeCommand {
     match command {
-        command => {
-            match command {
-                0=>RefereeCommand::Halt,
-                1=>RefereeCommand::Stop,
-                2=>RefereeCommand::NormalStart,
-                3=>RefereeCommand::ForceStart ,
-                4=>RefereeCommand::PrepareKickoff(TeamColor::Yellow),
-                5=>RefereeCommand::PrepareKickoff(TeamColor::Blue),
-                6=>RefereeCommand::PreparePenalty(TeamColor::Yellow) ,
-                7=>RefereeCommand::PreparePenalty(TeamColor::Blue) ,
-                8=>RefereeCommand::DirectFree(TeamColor::Yellow),
-                9=>RefereeCommand::DirectFree(TeamColor::Blue),
-                10=>RefereeCommand::IndirectFree(TeamColor::Yellow),
-                11=>RefereeCommand::IndirectFree(TeamColor::Blue),
-                12=>RefereeCommand::Timeout(TeamColor::Yellow),
-                13=>RefereeCommand::Timeout(TeamColor::Blue),
-                14=>RefereeCommand::Goal(TeamColor::Yellow) ,
-                15=>RefereeCommand::Goal(TeamColor::Blue),
-                16=>RefereeCommand::BallPlacement(TeamColor::Yellow),
-                17=>RefereeCommand::BallPlacement(TeamColor::Blue),
-                _ => RefereeCommand::Unknow
-            }
-        }
+        command => match command {
+            0 => RefereeCommand::Halt,
+            1 => RefereeCommand::Stop,
+            2 => RefereeCommand::NormalStart,
+            3 => RefereeCommand::ForceStart,
+            4 => RefereeCommand::PrepareKickoff(TeamColor::Yellow),
+            5 => RefereeCommand::PrepareKickoff(TeamColor::Blue),
+            6 => RefereeCommand::PreparePenalty(TeamColor::Yellow),
+            7 => RefereeCommand::PreparePenalty(TeamColor::Blue),
+            8 => RefereeCommand::DirectFree(TeamColor::Yellow),
+            9 => RefereeCommand::DirectFree(TeamColor::Blue),
+            10 => RefereeCommand::IndirectFree(TeamColor::Yellow),
+            11 => RefereeCommand::IndirectFree(TeamColor::Blue),
+            12 => RefereeCommand::Timeout(TeamColor::Yellow),
+            13 => RefereeCommand::Timeout(TeamColor::Blue),
+            14 => RefereeCommand::Goal(TeamColor::Yellow),
+            15 => RefereeCommand::Goal(TeamColor::Blue),
+            16 => RefereeCommand::BallPlacement(TeamColor::Yellow),
+            17 => RefereeCommand::BallPlacement(TeamColor::Blue),
+            _ => RefereeCommand::Unknow,
+        },
     }
 }
-fn to_team_infos(infos: &game_controller_packet::referee::TeamInfo) -> TeamInfo{
-    let _infos = TeamInfo{
+fn to_team_infos(infos: &game_controller_packet::referee::TeamInfo) -> TeamInfo {
+    let _infos = TeamInfo {
         name: infos.name.clone(),
         score: infos.score,
         red_cards: infos.red_cards,
-        yellow_card_times:infos.yellow_card_times.clone(),
+        yellow_card_times: infos.yellow_card_times.clone(),
         yellow_cards: infos.yellow_cards,
         timeouts: infos.timeouts,
         timeout_time: infos.timeout_time,
@@ -63,54 +61,53 @@ fn to_team_infos(infos: &game_controller_packet::referee::TeamInfo) -> TeamInfo{
     };
     _infos
 }
-fn convert_referee_protobuf(packet: &game_controller_packet::Referee, team_color: &TeamColor) -> Referee {
+fn convert_referee_protobuf(
+    packet: &game_controller_packet::Referee,
+    team_color: &TeamColor,
+) -> Referee {
     dbg!(packet);
     let ally = match team_color {
         TeamColor::Yellow => to_team_infos(&packet.yellow),
-        TeamColor::Blue => to_team_infos(&packet.blue)
+        TeamColor::Blue => to_team_infos(&packet.blue),
     };
     let enemy = match team_color.opposite() {
         TeamColor::Yellow => to_team_infos(&packet.yellow),
-        TeamColor::Blue => to_team_infos(&packet.blue)
+        TeamColor::Blue => to_team_infos(&packet.blue),
     };
     let _referee = Referee {
         source_identifier: packet.source_identifier.clone(),
         match_type: match packet.match_type {
-            Some(match_type) => {
-                match match_type {
-                    1 => Some(MatchType::GroupPhase),
-                    2 => Some(MatchType::EliminationPhase),
-                    3 => Some(MatchType::Friendly),
-                    _ => Some(MatchType::UnknownMatch),
-                }
+            Some(match_type) => match match_type {
+                1 => Some(MatchType::GroupPhase),
+                2 => Some(MatchType::EliminationPhase),
+                3 => Some(MatchType::Friendly),
+                _ => Some(MatchType::UnknownMatch),
             },
             None => None,
         },
         packet_timestamp: convert_timestamp_to_datetime(packet.packet_timestamp),
         stage: match packet.stage {
-            stage => {
-                match stage {
-                    0 => Stage::NormalFirstHalfPre ,
-                    1 => Stage::NormalFirstHalf,
-                    2 => Stage::NormalHalfTime,
-                    3 => Stage::NormalSecondHalfPre,
-                    4 => Stage::NormalSecondHalf,
-                    5 => Stage::ExtraTimeBreak,
-                    6 => Stage::ExtraFirstHalfPre,
-                    7 => Stage::ExtraFirstHalf,
-                    8 => Stage::ExtraHalfTime,
-                    9 => Stage::ExtraSecondHalfPre ,
-                    10 => Stage::ExtraSecondHalf ,
-                    11 => Stage::PenaltyShootoutBreak ,
-                    12 => Stage::PenaltyShootout,
-                    13 => Stage::PostGame,
-                    _ => Stage::Unknow
-                }
-            }
+            stage => match stage {
+                0 => Stage::NormalFirstHalfPre,
+                1 => Stage::NormalFirstHalf,
+                2 => Stage::NormalHalfTime,
+                3 => Stage::NormalSecondHalfPre,
+                4 => Stage::NormalSecondHalf,
+                5 => Stage::ExtraTimeBreak,
+                6 => Stage::ExtraFirstHalfPre,
+                7 => Stage::ExtraFirstHalf,
+                8 => Stage::ExtraHalfTime,
+                9 => Stage::ExtraSecondHalfPre,
+                10 => Stage::ExtraSecondHalf,
+                11 => Stage::PenaltyShootoutBreak,
+                12 => Stage::PenaltyShootout,
+                13 => Stage::PostGame,
+                _ => Stage::Unknow,
+            },
         },
         stage_time_left: match packet.stage_time_left {
             Some(duration_value) => Some(Duration::seconds(duration_value as i64)),
-            None => Some(Duration::zero())
+            None => Some(Duration::zero()),
         },
         command: get_command(packet.command),
         command_counter: packet.command_counter,
@@ -119,27 +116,29 @@ fn convert_referee_protobuf(packet: &game_controller_packet::Referee, team_color
         enemy: enemy,
         designated_position: match &packet.designated_position {
             Some(position) => match position {
-                _ => Some(Point2::new(position.x as f64, position.y as f64))
+                _ => Some(Point2::new(position.x as f64, position.y as f64)),
             },
-            None => None
+            None => None,
         },
         positive_half: match packet.blue_team_on_positive_half {
-            Some(blue_positive) => if blue_positive {
-                Some(TeamColor::Blue)
-            }else{
-                Some(TeamColor::Yellow)
-            },
-            None => None
+            Some(blue_positive) => {
+                if blue_positive {
+                    Some(TeamColor::Blue)
+                } else {
+                    Some(TeamColor::Yellow)
+                }
+            }
+            None => None,
         },
         next_command: match packet.next_command {
             Some(command) => Some(get_command(command)),
-            None => None
+            None => None,
         },
         game_events: vec![],
         game_event_proposals: vec![],
         current_action_time_remaining: match packet.current_action_time_remaining {
             Some(duration_value) => Some(Duration::seconds(duration_value as i64)),
-            None => Some(Duration::zero())
+            None => Some(Duration::zero()),
         },
     };
     _referee
@@ -152,7 +151,7 @@ impl PreFilter for GameControllerPreFilter {
         team_color: &TeamColor,
         filter_data: &mut FilterData,
     ) {
-        inbound_data.gc_packet.iter().for_each(|gc_packet|{
+        inbound_data.gc_packet.iter().for_each(|gc_packet| {
             convert_referee_protobuf(gc_packet, team_color);
         });
         // TODO: The referee message needs to be inside our own framework.

--- a/crates/crabe_filter/src/pre_filter/game_controller.rs
+++ b/crates/crabe_filter/src/pre_filter/game_controller.rs
@@ -182,7 +182,6 @@ fn map_origin(origin: String) -> EventOrigin{
 }
 
 fn map_game_event(mut game_event: ProtocolEvent) -> Option<GameEvent> {
-    println!("test game");
     let created_timestamp = game_event.created_timestamp;
     let event = game_event.event.map(map_event).flatten();
     /* 

--- a/crates/crabe_filter/src/pre_filter/game_controller.rs
+++ b/crates/crabe_filter/src/pre_filter/game_controller.rs
@@ -1,7 +1,7 @@
-use crabe_framework::data::input::InboundData;
-use crabe_framework::data::world::TeamColor;
 use crate::data::FilterData;
 use crate::pre_filter::PreFilter;
+use crabe_framework::data::input::InboundData;
+use crabe_framework::data::world::TeamColor;
 
 pub struct GameControllerPreFilter;
 
@@ -20,6 +20,8 @@ impl PreFilter for GameControllerPreFilter {
     ) {
         // TODO: this allocates a ton
         // dbg!(&inbound_data.gc_packet);
-        filter_data.referee.extend(inbound_data.gc_packet.iter().map(|p| p.clone()));
+        filter_data
+            .referee
+            .extend(inbound_data.gc_packet.iter().map(|p| p.clone()));
     }
 }

--- a/crates/crabe_filter/src/pre_filter/game_controller.rs
+++ b/crates/crabe_filter/src/pre_filter/game_controller.rs
@@ -14,10 +14,9 @@ impl PreFilter for GameControllerPreFilter {
         _team_color: &TeamColor,
         filter_data: &mut FilterData,
     ) {
-        // TODO: this allocates a ton
-        // dbg!(&inbound_data.gc_packet);
+        /// TODO: The referee message needs to be inside our own framework.
         filter_data
             .referee
-            .extend(inbound_data.gc_packet.iter().map(|p| p.clone()));
+            .extend(inbound_data.gc_packet.iter().cloned());
     }
 }

--- a/crates/crabe_filter/src/pre_filter/game_controller.rs
+++ b/crates/crabe_filter/src/pre_filter/game_controller.rs
@@ -14,7 +14,7 @@ use crabe_protocol::protobuf::game_controller_packet::{GameEvent as ProtocolEven
 use crabe_protocol::protobuf::game_controller_packet::referee::{Command as ProtocolCommand, Command, Point as ProtocolPoint, Stage as ProtocolStage};
 use crate::data::referee::event::{Event, AimlessKick, AttackerDoubleTouchedBall, AttackerTooCloseToDefenseArea, AttackerTouchedBallInDefenseArea, BallLeftField, BotCrashDrawn, BotCrashUnique, BotDribbledBallTooFar, BotHeldBallDeliberately, BotInterferedPlacement, BotKickedBallTooFast, BotPushedBot, BotTippedOver, BotTooFastInStop, BoundaryCrossing, DefenderInDefenseArea, DefenderTooCloseToKickPoint, GameEvent, Goal, KeeperHeldBall, MultipleFouls, NoProgressInGame, PenaltyKickFailed, PlacementFailed, PlacementSucceeded, TooManyRobots, UnsportingBehavior};
 
-use crate::data::referee::{GameEventProposalGroup, Referee, RefereeCommand, Stage};
+use crate::data::referee::{GameEventProposalGroup, Referee, RefereeCommand, Stage, TeamInfo};
 use crabe_protocol::protobuf::game_controller_packet::Team as ProtocolTeam;
 pub struct GameControllerPreFilter;
 

--- a/crates/crabe_filter/src/pre_filter/vision.rs
+++ b/crates/crabe_filter/src/pre_filter/vision.rs
@@ -6,7 +6,7 @@ use crabe_framework::data::world::TeamColor;
 
 mod detection {
     use crate::data::{FilterData, FrameInfo};
-    use crate::pre_filter::create_date_time;
+    use crate::pre_filter::common::create_date_time;
     use chrono::Utc;
     use crabe_framework::data::world::TeamColor;
     use crabe_protocol::protobuf::vision_packet::SslDetectionFrame;
@@ -125,7 +125,7 @@ mod detection {
             camera_id: detection.camera_id,
             frame_number: detection.frame_number,
             // TODO: Add detection.t_capture with not UTC now + Add detection.t_sent
-            t_capture: create_date_time(Utc::now().timestamp() as f64),
+            t_capture: create_date_time(Utc::now().timestamp() as i64),
         };
 
         let mut robot_detection_info = robot::RobotDetectionInfo {

--- a/crates/crabe_filter/src/pre_filter/vision.rs
+++ b/crates/crabe_filter/src/pre_filter/vision.rs
@@ -140,6 +140,7 @@ mod detection {
         let frame_info = FrameInfo {
             camera_id: detection.camera_id,
             frame_number: detection.frame_number,
+            // TODO: Add detection.t_capture with not UTC now + Add detection.t_sent
             t_capture: create_date_time(Utc::now().timestamp() as f64),
         };
 

--- a/crates/crabe_filter/src/pre_filter/vision.rs
+++ b/crates/crabe_filter/src/pre_filter/vision.rs
@@ -226,11 +226,11 @@ impl VisionFilter {
 impl PreFilter for VisionFilter {
     fn step(
         &mut self,
-        inbound_data: &InboundData,
+        inbound_data: &mut InboundData,
         team_color: &TeamColor,
         filter_data: &mut FilterData,
     ) {
-        inbound_data.vision_packet.iter().for_each(|packet| {
+        inbound_data.vision_packet.drain(..).for_each(|packet| {
             if let Some(detection) = packet.detection.as_ref() {
                 detection::handle_detection(detection, filter_data, team_color);
             }

--- a/crates/crabe_filter/src/pre_filter/vision.rs
+++ b/crates/crabe_filter/src/pre_filter/vision.rs
@@ -6,10 +6,10 @@ use crabe_framework::data::world::TeamColor;
 
 mod detection {
     use crate::data::{FilterData, FrameInfo};
-    use chrono::{DateTime, LocalResult, TimeZone, Utc};
+    use crate::pre_filter::create_date_time;
+    use chrono::Utc;
     use crabe_framework::data::world::TeamColor;
     use crabe_protocol::protobuf::vision_packet::SslDetectionFrame;
-    use log::error;
 
     mod robot {
         use crate::data::{camera::CamRobot, FrameInfo, TrackedRobot, TrackedRobotMap};
@@ -113,22 +113,6 @@ mod detection {
             });
 
             detection.tracked.packets.extend(ball_packets);
-        }
-    }
-
-    fn create_date_time(t_capture: f64) -> DateTime<Utc> {
-        match Utc.timestamp_opt((t_capture) as i64, 0) {
-            LocalResult::Single(dt) => dt,
-            LocalResult::None => {
-                let now_utc = Utc::now();
-                error!("Invalid timestamp, using current time: {}", now_utc);
-                now_utc
-            }
-            LocalResult::Ambiguous(dt_min, dt_max) => {
-                let dt_midpoint = dt_min + (dt_max - dt_min) / 2;
-                error!("Ambiguous timestamp resolved to midpoint: {}", dt_midpoint);
-                dt_midpoint
-            }
         }
     }
 

--- a/crates/crabe_framework/Cargo.toml
+++ b/crates/crabe_framework/Cargo.toml
@@ -7,11 +7,11 @@ authors = ["NAMeC"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.3.0", features = ["derive"] }
-serde = { version= "1.0.163", features = ["derive"] }
+clap = { version = "4.3.3", features = ["derive"] }
+serde = { version= "1.0.164", features = ["derive"] }
 serde_json = "1.0.96"
 nalgebra = { version = "0.32.2", features = ["serde-serialize"] }
 crabe_protocol = { path = "../crabe_protocol" }
 crabe_math = { path = "../crabe_math" }
-chrono={ version="0.4.25", features = ["serde"]}
+chrono={ version="0.4.26", features = ["serde"]}
 serde_with = "3.0.0"

--- a/crates/crabe_framework/Cargo.toml
+++ b/crates/crabe_framework/Cargo.toml
@@ -13,5 +13,5 @@ serde_json = "1.0.96"
 nalgebra = { version = "0.32.2", features = ["serde-serialize"] }
 crabe_protocol = { path = "../crabe_protocol" }
 crabe_math = { path = "../crabe_math" }
-chrono={ version="0.4.24", features = ["serde"]}
+chrono={ version="0.4.25", features = ["serde"]}
 serde_with = "3.0.0"

--- a/crates/crabe_framework/Cargo.toml
+++ b/crates/crabe_framework/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["NAMeC"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.3.3", features = ["derive"] }
+clap = { version = "4.3.4", features = ["derive"] }
 serde = { version= "1.0.164", features = ["derive"] }
 serde_json = "1.0.96"
 nalgebra = { version = "0.32.2", features = ["serde-serialize"] }

--- a/crates/crabe_framework/src/config.rs
+++ b/crates/crabe_framework/src/config.rs
@@ -9,4 +9,7 @@ pub struct CommonConfig {
     /// Whether robots are operating in the real world or in simulation.
     #[arg(short, long)]
     pub real: bool,
+    /// Specifies whether to activate the game-controller of the Robocup SSL.
+    #[arg(long)]
+    pub gc: bool,
 }

--- a/crates/crabe_framework/src/data.rs
+++ b/crates/crabe_framework/src/data.rs
@@ -1,6 +1,7 @@
 /// The `annotation` module contains data structures and functionality for managing
 /// graphical annotations to be drawn on the SSL RoboCup field viewer.
 pub mod annotation;
+pub mod event;
 /// The geometry module contains utility functions and structures related to geometry and
 /// coordinates of the SSL field.
 pub mod geometry;
@@ -14,4 +15,3 @@ pub mod tool;
 /// The world module contains the data structures for representing the state of the world
 /// in the control system. It includes information about robots, the ball, and the field.
 pub mod world;
-pub mod event;

--- a/crates/crabe_framework/src/data.rs
+++ b/crates/crabe_framework/src/data.rs
@@ -1,7 +1,6 @@
 /// The `annotation` module contains data structures and functionality for managing
 /// graphical annotations to be drawn on the SSL RoboCup field viewer.
 pub mod annotation;
-pub mod event;
 /// The geometry module contains utility functions and structures related to geometry and
 /// coordinates of the SSL field.
 pub mod geometry;

--- a/crates/crabe_framework/src/data.rs
+++ b/crates/crabe_framework/src/data.rs
@@ -14,3 +14,4 @@ pub mod tool;
 /// The world module contains the data structures for representing the state of the world
 /// in the control system. It includes information about robots, the ball, and the field.
 pub mod world;
+pub mod event;

--- a/crates/crabe_framework/src/data/event.rs
+++ b/crates/crabe_framework/src/data/event.rs
@@ -1,13 +1,12 @@
-use chrono::Duration;
-use nalgebra::Point2;
-use serde::Serialize;
 use crate::data::world::TeamColor;
-use crabe_protocol::protobuf::game_controller_packet::referee::Point;
+use chrono::Duration;
+
+use nalgebra::Point2;
 
 #[derive(Clone, Debug)]
 pub enum EventOrigin {
     GameController,
-    Autorefs(Vec<String>)
+    Autorefs(Vec<String>),
 }
 
 #[derive(Clone, Debug)]
@@ -35,7 +34,7 @@ pub struct Goal {
     pub max_ball_height: Option<f64>,
     pub num_bots_by_team: Option<u32>,
     pub last_touch_by_team: Option<u64>,
-    pub message: Option<String>
+    pub message: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -43,7 +42,7 @@ pub struct BotTooFastInStop {
     pub by_team: TeamColor,
     pub by_bot: Option<u32>,
     pub location: Option<Point2<f64>>,
-    pub speed: Option<f64>
+    pub speed: Option<f64>,
 }
 
 #[derive(Clone, Debug)]
@@ -51,7 +50,7 @@ pub struct DefenderTooCloseToKickPoint {
     pub by_team: TeamColor,
     pub by_bot: Option<u32>,
     pub location: Option<Point2<f64>>,
-    pub distance: Option<f64>
+    pub distance: Option<f64>,
 }
 
 #[derive(Clone, Debug)]
@@ -60,7 +59,7 @@ pub struct BotCrashDrawn {
     pub bot_yellow: Option<u32>,
     pub crash_speed: Option<f64>,
     pub speed_diff: Option<f64>,
-    pub crash_angle: Option<f64>
+    pub crash_angle: Option<f64>,
 }
 
 #[derive(Clone, Debug)]
@@ -71,7 +70,7 @@ pub struct BotCrashUnique {
     pub location: Option<Point2<f64>>,
     pub crash_speed: Option<f64>,
     pub speed_diff: Option<f64>,
-    pub crash_angle: Option<f64>
+    pub crash_angle: Option<f64>,
 }
 
 #[derive(Clone, Debug)]
@@ -80,7 +79,7 @@ pub struct BotPushedBot {
     pub violator: Option<u32>,
     pub victim: Option<u32>,
     pub location: Option<Point2<f64>>,
-    pub pushed_distance: Option<f64>
+    pub pushed_distance: Option<f64>,
 }
 
 #[derive(Clone, Debug)]
@@ -88,7 +87,7 @@ pub struct BotTippedOver {
     pub by_team: TeamColor,
     pub by_bot: Option<u32>,
     pub location: Option<Point2<f64>>,
-    pub ball_location: Option<Point2<f64>>
+    pub ball_location: Option<Point2<f64>>,
 }
 
 #[derive(Clone, Debug)]
@@ -105,9 +104,8 @@ pub struct DefenderInDefenseAreaPartially {
     pub by_bot: Option<u32>,
     pub location: Option<Point2<f64>>,
     pub distance: Option<f64>,
-    pub ball_location: Option<Point2<f64>>
+    pub ball_location: Option<Point2<f64>>,
 }
-
 
 #[derive(Clone, Debug)]
 pub struct AttackerTouchedBallInDefenseArea {
@@ -131,15 +129,14 @@ pub struct BotDribbledBallTooFar {
     pub by_team: TeamColor,
     pub by_bot: Option<u32>,
     pub start: Option<Point2<f64>>,
-    pub end: Option<Point2<f64>>
+    pub end: Option<Point2<f64>>,
 }
-
 
 #[derive(Clone, Debug)]
 pub struct AttackerDoubleTouchedBall {
     pub by_team: TeamColor,
     pub by_bot: Option<u32>,
-    pub location: Option<Point2<f64>>
+    pub location: Option<Point2<f64>>,
 }
 
 #[derive(Clone, Debug)]
@@ -175,7 +172,7 @@ pub struct MultipleFouls {
 #[derive(Clone, Debug)]
 pub struct NoProgressInGame {
     pub location: Option<Point2<f64>>,
-    pub time: Option<Duration>
+    pub time: Option<Duration>,
 }
 
 #[derive(Clone, Debug)]
@@ -200,7 +197,7 @@ pub struct UnsportingBehaviorMajor {
 pub struct KeeperHeldBall {
     pub by_team: TeamColor,
     pub location: Option<Point2<f64>>,
-    pub duration: Option<Duration>
+    pub duration: Option<Duration>,
 }
 
 #[derive(Clone, Debug)]
@@ -208,7 +205,7 @@ pub struct PlacementSucceeded {
     pub by_team: TeamColor,
     pub time_taken: Option<f64>,
     pub precision: Option<f64>,
-    pub distance: Option<f64>
+    pub distance: Option<f64>,
 }
 
 #[derive(Clone, Debug)]
@@ -216,20 +213,19 @@ pub struct TooManyRobots {
     pub by_team: TeamColor,
     pub num_robots_allowed: Option<u32>,
     pub num_robots_on_field: Option<u32>,
-    pub ball_location: Option<Point2<f64>>
+    pub ball_location: Option<Point2<f64>>,
 }
-
 
 #[derive(Clone, Debug)]
 pub struct BoundaryCrossing {
     pub by_team: TeamColor,
-    pub location: Option<Point2<f64>>
+    pub location: Option<Point2<f64>>,
 }
 
 #[derive(Clone, Debug)]
 pub struct PenaltyKickFailed {
     pub by_team: TeamColor,
-    pub location: Option<Point2<f64>>
+    pub location: Option<Point2<f64>>,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/crabe_framework/src/data/event.rs
+++ b/crates/crabe_framework/src/data/event.rs
@@ -1,0 +1,272 @@
+use chrono::Duration;
+use nalgebra::Point2;
+use serde::Serialize;
+use crate::data::world::TeamColor;
+use crabe_protocol::protobuf::game_controller_packet::referee::Point;
+
+#[derive(Clone, Debug)]
+pub enum EventOrigin {
+    GameController,
+    Autorefs(Vec<String>)
+}
+
+#[derive(Clone, Debug)]
+pub struct BallLeftField {
+    pub by_team: TeamColor,
+    pub by_bot: Option<u32>,
+    pub location: Option<Point2<f64>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct AimlessKick {
+    pub by_team: TeamColor,
+    pub by_bot: Option<u32>,
+    pub location: Option<Point2<f64>>,
+    pub kick_location: Option<Point2<f64>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Goal {
+    pub by_team: TeamColor,
+    pub kicking_team: Option<TeamColor>,
+    pub kicking_bot: Option<u32>,
+    pub location: Option<Point2<f64>>,
+    pub kick_location: Option<Point2<f64>>,
+    pub max_ball_height: Option<f64>,
+    pub num_bots_by_team: Option<u32>,
+    pub last_touch_by_team: Option<u64>,
+    pub message: Option<String>
+}
+
+#[derive(Clone, Debug)]
+pub struct BotTooFastInStop {
+    pub by_team: TeamColor,
+    pub by_bot: Option<u32>,
+    pub location: Option<Point2<f64>>,
+    pub speed: Option<f64>
+}
+
+#[derive(Clone, Debug)]
+pub struct DefenderTooCloseToKickPoint {
+    pub by_team: TeamColor,
+    pub by_bot: Option<u32>,
+    pub location: Option<Point2<f64>>,
+    pub distance: Option<f64>
+}
+
+#[derive(Clone, Debug)]
+pub struct BotCrashDrawn {
+    pub bot_blue: Option<u32>,
+    pub bot_yellow: Option<u32>,
+    pub crash_speed: Option<f64>,
+    pub speed_diff: Option<f64>,
+    pub crash_angle: Option<f64>
+}
+
+#[derive(Clone, Debug)]
+pub struct BotCrashUnique {
+    pub by_team: TeamColor,
+    pub violator: Option<u32>,
+    pub victim: Option<u32>,
+    pub location: Option<Point2<f64>>,
+    pub crash_speed: Option<f64>,
+    pub speed_diff: Option<f64>,
+    pub crash_angle: Option<f64>
+}
+
+#[derive(Clone, Debug)]
+pub struct BotPushedBot {
+    pub by_team: TeamColor,
+    pub violator: Option<u32>,
+    pub victim: Option<u32>,
+    pub location: Option<Point2<f64>>,
+    pub pushed_distance: Option<f64>
+}
+
+#[derive(Clone, Debug)]
+pub struct BotTippedOver {
+    pub by_team: TeamColor,
+    pub by_bot: Option<u32>,
+    pub location: Option<Point2<f64>>,
+    pub ball_location: Option<Point2<f64>>
+}
+
+#[derive(Clone, Debug)]
+pub struct DefenderInDefenseArea {
+    pub by_team: TeamColor,
+    pub by_bot: Option<u32>,
+    pub location: Option<Point2<f64>>,
+    pub distance: Option<f64>,
+}
+
+#[derive(Clone, Debug)]
+pub struct DefenderInDefenseAreaPartially {
+    pub by_team: TeamColor,
+    pub by_bot: Option<u32>,
+    pub location: Option<Point2<f64>>,
+    pub distance: Option<f64>,
+    pub ball_location: Option<Point2<f64>>
+}
+
+
+#[derive(Clone, Debug)]
+pub struct AttackerTouchedBallInDefenseArea {
+    pub by_team: TeamColor,
+    pub by_bot: Option<u32>,
+    pub location: Option<Point2<f64>>,
+    pub distance: Option<f64>,
+}
+
+#[derive(Clone, Debug)]
+pub struct BotKickedBallTooFast {
+    pub by_team: TeamColor,
+    pub by_bot: Option<u32>,
+    pub location: Option<Point2<f64>>,
+    pub initial_ball_speed: Option<f64>,
+    pub chipped: Option<bool>,
+}
+
+#[derive(Clone, Debug)]
+pub struct BotDribbledBallTooFar {
+    pub by_team: TeamColor,
+    pub by_bot: Option<u32>,
+    pub start: Option<Point2<f64>>,
+    pub end: Option<Point2<f64>>
+}
+
+
+#[derive(Clone, Debug)]
+pub struct AttackerDoubleTouchedBall {
+    pub by_team: TeamColor,
+    pub by_bot: Option<u32>,
+    pub location: Option<Point2<f64>>
+}
+
+#[derive(Clone, Debug)]
+pub struct AttackerTooCloseToDefenseArea {
+    pub by_team: TeamColor,
+    pub by_bot: Option<u32>,
+    pub location: Option<Point2<f64>>,
+    pub distance: Option<f64>,
+    pub ball_location: Option<Point2<f64>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct BotHeldBallDeliberately {
+    pub by_team: TeamColor,
+    pub by_bot: Option<u32>,
+    pub location: Option<Point2<f64>>,
+    pub duration: Option<Duration>,
+}
+
+#[derive(Clone, Debug)]
+pub struct BotInterferedPlacement {
+    pub by_team: TeamColor,
+    pub by_bot: Option<u32>,
+    pub location: Option<Point2<f64>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct MultipleFouls {
+    pub by_team: TeamColor,
+    pub caused_game_events: Vec<GameEvent>,
+}
+
+#[derive(Clone, Debug)]
+pub struct NoProgressInGame {
+    pub location: Option<Point2<f64>>,
+    pub time: Option<Duration>
+}
+
+#[derive(Clone, Debug)]
+pub struct PlacementFailed {
+    pub location: Option<Point2<f64>>,
+    pub remaining_distance: f64,
+}
+
+#[derive(Clone, Debug)]
+pub struct UnsportingBehaviorMinor {
+    pub by_team: TeamColor,
+    pub reason: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct UnsportingBehaviorMajor {
+    pub by_team: TeamColor,
+    pub reason: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct KeeperHeldBall {
+    pub by_team: TeamColor,
+    pub location: Option<Point2<f64>>,
+    pub duration: Option<Duration>
+}
+
+#[derive(Clone, Debug)]
+pub struct PlacementSucceeded {
+    pub by_team: TeamColor,
+    pub time_taken: Option<f64>,
+    pub precision: Option<f64>,
+    pub distance: Option<f64>
+}
+
+#[derive(Clone, Debug)]
+pub struct TooManyRobots {
+    pub by_team: TeamColor,
+    pub num_robots_allowed: Option<u32>,
+    pub num_robots_on_field: Option<u32>,
+    pub ball_location: Option<Point2<f64>>
+}
+
+
+#[derive(Clone, Debug)]
+pub struct BoundaryCrossing {
+    pub by_team: TeamColor,
+    pub location: Option<Point2<f64>>
+}
+
+#[derive(Clone, Debug)]
+pub struct PenaltyKickFailed {
+    pub by_team: TeamColor,
+    pub location: Option<Point2<f64>>
+}
+
+#[derive(Clone, Debug)]
+pub enum GameEvent {
+    Unknown,
+    BallLeftFieldTouchLine(BallLeftField),
+    BallLeftFieldGoalLine(BallLeftField),
+    AimlessKick(AimlessKick),
+    AttackerTooCloseToDefenseArea(AttackerTooCloseToDefenseArea),
+    DefenderInDefenseArea(DefenderInDefenseArea),
+    BoundaryCrossing(BoundaryCrossing),
+    KeeperHeldBall(KeeperHeldBall),
+    BotDribbledBallTooFar(BotDribbledBallTooFar),
+    BotPushedBot(BotPushedBot),
+    BotHeldBallDeliberately(BotHeldBallDeliberately),
+    BotTippedOver(BotTippedOver),
+    AttackerTouchedBallInDefenseArea(AttackerTouchedBallInDefenseArea),
+    BotKickedBallTooFast(BotKickedBallTooFast),
+    BotCrashUnique(BotCrashUnique),
+    BotCrashDrawn(BotCrashDrawn),
+    DefenderTooCloseToKickPoint(DefenderTooCloseToKickPoint),
+    BotTooFastInStop(BotTooFastInStop),
+    BotInterferedPlacement(BotInterferedPlacement),
+    PossibleGoal(Goal),
+    Goal(Goal),
+    InvalidGoal(Goal),
+    AttackerDoubleTouchedBall(AttackerDoubleTouchedBall),
+    PlacementSucceeded(PlacementSucceeded),
+    PenaltyKickFailed(PenaltyKickFailed),
+    NoProgressInGame(NoProgressInGame),
+    PlacementFailed(PlacementFailed),
+    MultipleCards(TeamColor),
+    MultipleFouls(MultipleFouls),
+    TooManyRobots(TooManyRobots),
+    BotSubstitution(TeamColor),
+    ChallengeFlag(TeamColor),
+    EmergencyStop(TeamColor),
+    UnsportingBehaviorMinor(UnsportingBehaviorMinor),
+    UnsportingBehaviorMajor(UnsportingBehaviorMajor),
+}

--- a/crates/crabe_framework/src/data/world.rs
+++ b/crates/crabe_framework/src/data/world.rs
@@ -11,7 +11,9 @@ pub use self::ball::Ball;
 mod team;
 pub use self::team::{Team, TeamColor};
 
-mod game_data;
+pub mod game_data;
+pub mod game_state;
+pub use self::game_state::{GameState, HaltedState};
 pub use self::game_data::GameData;
 
 use crate::config::CommonConfig;

--- a/crates/crabe_framework/src/data/world.rs
+++ b/crates/crabe_framework/src/data/world.rs
@@ -11,8 +11,8 @@ pub use self::ball::Ball;
 mod team;
 pub use self::team::{Team, TeamColor};
 
-mod game_state;
-pub use self::game_state::GameState;
+mod game_data;
+pub use self::game_data::GameData;
 
 use crate::config::CommonConfig;
 use crate::data::geometry::Geometry;
@@ -26,7 +26,7 @@ use serde::Serialize;
 #[serde(rename_all = "camelCase")]
 pub struct World {
     /// The current state of the game.
-    pub state: GameState,
+    pub data: GameData,
     /// The geometry of the field, including its dimensions and the positions of goals and other areas.
     pub geometry: Geometry,
     /// A map of all the ally robots in the game, identified by their unique ID.
@@ -50,7 +50,7 @@ impl World {
             TeamColor::Blue
         };
         Self {
-            state: GameState::new(team_color),
+            data: GameData::new(team_color),
             geometry: Default::default(),
             allies_bot: Default::default(),
             enemies_bot: Default::default(),

--- a/crates/crabe_framework/src/data/world.rs
+++ b/crates/crabe_framework/src/data/world.rs
@@ -13,8 +13,8 @@ pub use self::team::{Team, TeamColor};
 
 pub mod game_data;
 pub mod game_state;
-pub use self::game_state::{GameState, HaltedState};
 pub use self::game_data::GameData;
+pub use self::game_state::{GameState, HaltedState};
 
 use crate::config::CommonConfig;
 use crate::data::geometry::Geometry;

--- a/crates/crabe_framework/src/data/world/game_data.rs
+++ b/crates/crabe_framework/src/data/world/game_data.rs
@@ -1,6 +1,6 @@
+use crate::data::world::game_state::{GameState, HaltedState};
 use crate::data::world::{Team, TeamColor};
 use serde::Serialize;
-use crate::data::world::game_state::{GameState, HaltedState};
 
 /// The `GameData` struct represents the state of the SSL game, including the teams and which team is on the positive half of the field.
 #[derive(Serialize, Clone, Debug)]
@@ -13,7 +13,7 @@ pub struct GameData {
     /// The color of the team that is on the positive half of the field.
     pub positive_half: TeamColor,
     /// The current game state
-    pub state: GameState
+    pub state: GameState,
 }
 
 impl GameData {
@@ -27,4 +27,3 @@ impl GameData {
         }
     }
 }
- 

--- a/crates/crabe_framework/src/data/world/game_data.rs
+++ b/crates/crabe_framework/src/data/world/game_data.rs
@@ -1,0 +1,30 @@
+use crate::data::world::{Team, TeamColor};
+use serde::Serialize;
+use crate::data::world::game_state::{GameState, HaltedState};
+
+/// The `GameData` struct represents the state of the SSL game, including the teams and which team is on the positive half of the field.
+#[derive(Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GameData {
+    /// The `Team` struct representing our ally team.
+    pub ally: Team,
+    /// The `Team` struct representing the enemy team.
+    pub enemy: Team,
+    /// The color of the team that is on the positive half of the field.
+    pub positive_half: TeamColor,
+    /// The current game state
+    pub state: GameState
+}
+
+impl GameData {
+    /// Creates a new `GameData` with the given `team_color` as the team color for the ally team, and the opposite team color for the enemy team.
+    pub fn new(team_color: TeamColor) -> Self {
+        Self {
+            ally: Team::with_color(team_color),
+            enemy: Team::with_color(team_color.opposite()),
+            positive_half: team_color.opposite(),
+            state: GameState::Halted(HaltedState::Halt),
+        }
+    }
+}
+ 

--- a/crates/crabe_framework/src/data/world/game_state.rs
+++ b/crates/crabe_framework/src/data/world/game_state.rs
@@ -1,35 +1,35 @@
-use serde::{Serialize};
 use crate::data::world::TeamColor;
+use serde::Serialize;
 
 #[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 pub enum GameState {
     Halted(HaltedState),
     Stopped(StoppedState),
-    Running(RunningState)
+    Running(RunningState),
 }
 
 #[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 pub enum HaltedState {
     Halt,
-    Timeout
+    Timeout,
 }
 
 #[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 pub enum StoppedState {
     Stop,
     PrepareKickoff,
     PreparePenalty,
-    BallPlacement
+    BallPlacement,
 }
 
 #[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 pub enum RunningState {
     KickOff(TeamColor),
     Penalty,
     FreeKick,
-    Run
+    Run,
 }

--- a/crates/crabe_framework/src/data/world/game_state.rs
+++ b/crates/crabe_framework/src/data/world/game_state.rs
@@ -1,25 +1,35 @@
-use crate::data::world::{Team, TeamColor};
-use serde::Serialize;
+use serde::{Serialize};
+use crate::data::world::TeamColor;
 
-/// The `GameState` struct represents the state of the SSL game, including the teams and which team is on the positive half of the field.
-#[derive(Serialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct GameState {
-    /// The `Team` struct representing our ally team.
-    pub ally: Team,
-    /// The `Team` struct representing the enemy team.
-    pub enemy: Team,
-    /// The color of the team that is on the positive half of the field.
-    pub positive_half: TeamColor,
+#[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all="camelCase")]
+pub enum GameState {
+    Halted(HaltedState),
+    Stopped(StoppedState),
+    Running(RunningState)
 }
 
-impl GameState {
-    /// Creates a new `GameState` with the given `team_color` as the team color for the ally team, and the opposite team color for the enemy team.
-    pub fn new(team_color: TeamColor) -> Self {
-        Self {
-            ally: Team::with_color(team_color),
-            enemy: Team::with_color(team_color.opposite()),
-            positive_half: team_color.opposite(),
-        }
-    }
+#[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all="camelCase")]
+pub enum HaltedState {
+    Halt,
+    Timeout
+}
+
+#[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all="camelCase")]
+pub enum StoppedState {
+    Stop,
+    PrepareKickoff,
+    PreparePenalty,
+    BallPlacement
+}
+
+#[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all="camelCase")]
+pub enum RunningState {
+    KickOff(TeamColor),
+    Penalty,
+    FreeKick,
+    Run
 }

--- a/crates/crabe_framework/src/data/world/game_state.rs
+++ b/crates/crabe_framework/src/data/world/game_state.rs
@@ -29,7 +29,7 @@ pub enum StoppedState {
 #[serde(rename_all = "camelCase")]
 pub enum RunningState {
     KickOff(TeamColor),
-    Penalty,
-    FreeKick,
+    Penalty(TeamColor),
+    FreeKick(TeamColor),
     Run,
 }

--- a/crates/crabe_framework/src/data/world/game_state.rs
+++ b/crates/crabe_framework/src/data/world/game_state.rs
@@ -20,9 +20,9 @@ pub enum HaltedState {
 #[serde(rename_all = "camelCase")]
 pub enum StoppedState {
     Stop,
-    PrepareKickoff,
-    PreparePenalty,
-    BallPlacement,
+    PrepareKickoff(TeamColor),
+    PreparePenalty(TeamColor),
+    BallPlacement(TeamColor),
 }
 
 #[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]

--- a/crates/crabe_framework/src/data/world/team.rs
+++ b/crates/crabe_framework/src/data/world/team.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// The `TeamColor` enum represents the color of a team in the SSL game, either blue or yellow.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Eq, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum TeamColor {
     Blue,

--- a/crates/crabe_guard/Cargo.toml
+++ b/crates/crabe_guard/Cargo.toml
@@ -8,5 +8,5 @@ authors = ["NAMeC"]
 
 [dependencies]
 log = "0.4.19"
-clap = { version = "4.3.3", features = ["derive"] }
+clap = { version = "4.3.4", features = ["derive"] }
 crabe_framework = { path = "../crabe_framework" }

--- a/crates/crabe_guard/Cargo.toml
+++ b/crates/crabe_guard/Cargo.toml
@@ -7,6 +7,6 @@ authors = ["NAMeC"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-log = "0.4.18"
-clap = { version = "4.3.0", features = ["derive"] }
+log = "0.4.19"
+clap = { version = "4.3.3", features = ["derive"] }
 crabe_framework = { path = "../crabe_framework" }

--- a/crates/crabe_io/Cargo.toml
+++ b/crates/crabe_io/Cargo.toml
@@ -9,8 +9,8 @@ authors = ["NAMeC"]
 [dependencies]
 prost = "0.11.9"
 bytes= "1.4"
-log = "0.4.18"
-clap = { version = "4.3.0", features = ["derive"] }
+log = "0.4.19"
+clap = { version = "4.3.3", features = ["derive"] }
 crabe_protocol = { path = "../crabe_protocol" }
 crabe_framework = { path = "../crabe_framework" }
 flume = "0.10.14"
@@ -18,7 +18,7 @@ tokio = { version = "1.28.2", features = ["full"] }
 tungstenite = "0.19.0"
 futures-util = "0.3.28"
 tokio-tungstenite = "0.19.0"
-serde = { version= "1.0.163", features = ["derive"] }
+serde = { version= "1.0.164", features = ["derive"] }
 serde_json = "1.0.96"
 serialport = { git= "https://github.com/metta-systems/serialport-rs.git" }
 serde_with = "3.0.0"

--- a/crates/crabe_io/Cargo.toml
+++ b/crates/crabe_io/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["NAMeC"]
 prost = "0.11.9"
 bytes= "1.4"
 log = "0.4.19"
-clap = { version = "4.3.3", features = ["derive"] }
+clap = { version = "4.3.4", features = ["derive"] }
 crabe_protocol = { path = "../crabe_protocol" }
 crabe_framework = { path = "../crabe_framework" }
 flume = "0.10.14"

--- a/crates/crabe_io/src/league/game_controller/game_controller_thread.rs
+++ b/crates/crabe_io/src/league/game_controller/game_controller_thread.rs
@@ -25,7 +25,7 @@ impl GameController {
         let ipv4 = Ipv4Addr::from_str(cli.gc_ip.as_str())
             .expect("Failed to create an ipv4 address with the ip");
         let mut gc =
-            MulticastUDPReceiver::new(ipv4, cli.gc_port).expect("Failed to create vision receiver");
+            MulticastUDPReceiver::new(ipv4, cli.gc_port).expect("Failed to create gc receiver");
         let running = Arc::new(AtomicBool::new(true));
         let running_clone = Arc::clone(&running);
 

--- a/crates/crabe_io/src/pipeline/input.rs
+++ b/crates/crabe_io/src/pipeline/input.rs
@@ -8,9 +8,6 @@ use crabe_framework::data::output::FeedbackMap;
 
 #[derive(Args)]
 pub struct InputConfig {
-    #[arg(long)]
-    gc: bool,
-
     #[command(flatten)]
     #[command(next_help_heading = "Vision")]
     pub vision_cfg: VisionConfig,
@@ -36,7 +33,7 @@ impl InputPipeline {
             common_cfg,
         ))];
 
-        if input_cfg.gc {
+        if common_cfg.gc {
             tasks.push(Box::new(GameController::with_config(input_cfg.gc_cfg)));
         }
 

--- a/crates/crabe_math/Cargo.toml
+++ b/crates/crabe_math/Cargo.toml
@@ -8,4 +8,4 @@ authors = ["NAMeC"]
 
 [dependencies]
 nalgebra = { version = "0.32.2", features = ["serde-serialize"] }
-serde = { version= "1.0.163", features = ["derive"] }
+serde = { version= "1.0.164", features = ["derive"] }


### PR DESCRIPTION
This PR adds state machine on the project. It's a big PR !
 It includes an inactive filter if we didn't receive anything during a long time and supress robots.

## Features
 
- Add inactive filter to remove inactive robot (no vision since a lot of time) 
- Add GameState to Manager
- Move game_controller on common config
- Add filters to handle referee message
- Upgrade dependencies

## TODO

- [ ] Remove warnings
- [ ] Add ally/enemy penalty and kickoff of Game Manager
- [x] Referee struct is not used !
- [ ] Add more info for the team
- [x] Remove unreacheable! code (We don't want to have problem during our match)
- [x] Drain inbound_data
- [x] Translate packet protobuf to Referee internal struct