### PR TITLE
fix: fix nan filter

### DIFF
--- a/crates/crabe_guard/src/speed.rs
+++ b/crates/crabe_guard/src/speed.rs
@@ -35,32 +35,27 @@ impl Guard for SpeedGuard {
         _tool_commands: &mut ToolCommands,
     ) {
         commands.iter_mut().for_each(|(_id, command)| {
-            match command.forward_velocity {
-                f32::NAN => { command.forward_velocity = 0. }
-                _ => {
-                    command.forward_velocity = command
-                        .forward_velocity
-                        .clamp(-self.max_linear, self.max_linear);
-                }
-            };
+            if command.forward_velocity.is_nan() {
+                command.forward_velocity = 0.;
+            } else {
+                command.forward_velocity = command
+                    .forward_velocity
+                    .clamp(-self.max_linear, self.max_linear);
+            }
 
-            match command.left_velocity {
-                f32::NAN => { command.left_velocity = 0. }
-                _ => {
-                    command.left_velocity = command
-                        .left_velocity
-                        .clamp(-self.max_linear, self.max_linear);
-                }
-            };
+            if command.left_velocity.is_nan() {
+                command.left_velocity = 0.;
+            } else {
+                command.left_velocity = command
+                    .left_velocity
+                    .clamp(-self.max_linear, self.max_linear);
+            }
 
-            match command.angular_velocity {
-                f32::NAN => { command.angular_velocity = 0. }
-                _ => {
-                    command.angular_velocity = command
-                        .angular_velocity
-                        .clamp(-self.max_angular, self.max_angular);
-                }
-            };
+            if command.angular_velocity.is_nan() {
+                command.angular_velocity = command
+                    .angular_velocity
+                    .clamp(-self.max_angular, self.max_angular);
+            }
 
         });
     }


### PR DESCRIPTION
goddamn warn in Rust that was considered as an error by the docs but not the compiler