### PR TITLE
[DEPRECATED] Reimplementing features from RoboCup 2023

### DIFF
--- a/crates/crabe_decision/src/action.rs
+++ b/crates/crabe_decision/src/action.rs
@@ -74,6 +74,13 @@ impl ActionWrapper {
         }
     }
 
+    /// Clears the sequence of actions to be executed of all robot.
+    pub fn clear(&mut self) {
+        self.actions.iter_mut().for_each(|(_, sequencer)| {
+            sequencer.clear();
+        })
+    }
+
     /// Computes the sequence of actions to be executed for each robot and returns a
     /// `CommandMap` containing the commands to be sent to each robot.
     ///

--- a/crates/crabe_decision/src/strategy.rs
+++ b/crates/crabe_decision/src/strategy.rs
@@ -12,6 +12,10 @@ pub mod testing;
 /// through an `ActionWrapper` instance. A strategy can run for multiple time steps, until it decides to
 /// terminate by returning `true` from the `step` method.
 pub trait Strategy {
+
+    /// Name of the strategy, that we use as simple reference
+    fn name(&self) -> &'static str;
+
     /// Executes one step of the strategy, updating the state of the robot and issuing commands
     /// to it through the given `ActionWrapper`.
     ///

--- a/crates/crabe_decision/src/strategy/testing/square.rs
+++ b/crates/crabe_decision/src/strategy/testing/square.rs
@@ -22,6 +22,11 @@ impl Square {
 }
 
 impl Strategy for Square {
+
+    fn name(&self) -> &'static str {
+        "Square"
+    }
+
     /// Executes the Square strategy.
     ///
     /// This strategy commands the robot with the specified ID to move in a square shape in a

--- a/crates/crabe_framework/src/data/world.rs
+++ b/crates/crabe_framework/src/data/world.rs
@@ -12,7 +12,10 @@ mod team;
 pub use self::team::{Team, TeamColor};
 
 mod game_state;
+mod game_data;
+
 pub use self::game_state::GameState;
+pub use self::game_data::GameData;
 
 use crate::config::CommonConfig;
 use crate::data::geometry::Geometry;
@@ -26,7 +29,7 @@ use serde::Serialize;
 #[serde(rename_all = "camelCase")]
 pub struct World {
     /// The current state of the game.
-    pub state: GameState,
+    pub data: GameData,
     /// The geometry of the field, including its dimensions and the positions of goals and other areas.
     pub geometry: Geometry,
     /// A map of all the ally robots in the game, identified by their unique ID.
@@ -50,7 +53,7 @@ impl World {
             TeamColor::Blue
         };
         Self {
-            state: GameState::new(team_color),
+            data: GameData::new(team_color),
             geometry: Default::default(),
             allies_bot: Default::default(),
             enemies_bot: Default::default(),

--- a/crates/crabe_framework/src/data/world/game_data.rs
+++ b/crates/crabe_framework/src/data/world/game_data.rs
@@ -1,0 +1,30 @@
+use crate::data::world::{Team, TeamColor};
+use serde::Serialize;
+use crate::data::world::game_state::{GameState, HaltedState};
+
+/// The `GameData` struct represents the state of the SSL game, including the teams and which team is on the positive half of the field.
+#[derive(Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GameData {
+    /// The `Team` struct representing our ally team.
+    pub ally: Team,
+    /// The `Team` struct representing the enemy team.
+    pub enemy: Team,
+    /// The color of the team that is on the positive half of the field.
+    pub positive_half: TeamColor,
+    /// The current game state
+    pub state: GameState
+}
+
+impl GameData {
+    /// Creates a new `GameData` with the given `team_color` as the team color for the ally team, and the opposite team color for the enemy team.
+    pub fn new(team_color: TeamColor) -> Self {
+        Self {
+            ally: Team::with_color(team_color),
+            enemy: Team::with_color(team_color.opposite()),
+            positive_half: team_color.opposite(),
+            state: GameState::Halted(HaltedState::Halt),
+        }
+    }
+}
+ 

--- a/crates/crabe_framework/src/data/world/game_state.rs
+++ b/crates/crabe_framework/src/data/world/game_state.rs
@@ -1,25 +1,35 @@
-use crate::data::world::{Team, TeamColor};
 use serde::Serialize;
+use crate::data::world::TeamColor;
 
-/// The `GameState` struct represents the state of the SSL game, including the teams and which team is on the positive half of the field.
-#[derive(Serialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct GameState {
-    /// The `Team` struct representing our ally team.
-    pub ally: Team,
-    /// The `Team` struct representing the enemy team.
-    pub enemy: Team,
-    /// The color of the team that is on the positive half of the field.
-    pub positive_half: TeamColor,
+#[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all="camelCase")]
+pub enum GameState {
+    Halted(HaltedState),
+    Stopped(StoppedState),
+    Running(RunningState)
 }
 
-impl GameState {
-    /// Creates a new `GameState` with the given `team_color` as the team color for the ally team, and the opposite team color for the enemy team.
-    pub fn new(team_color: TeamColor) -> Self {
-        Self {
-            ally: Team::with_color(team_color),
-            enemy: Team::with_color(team_color.opposite()),
-            positive_half: team_color.opposite(),
-        }
-    }
+#[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all="camelCase")]
+pub enum HaltedState {
+    Halt,
+    Timeout
+}
+
+#[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all="camelCase")]
+pub enum StoppedState {
+    Stop,
+    PrepareKickoff,
+    PreparePenalty,
+    BallPlacement
+}
+
+#[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all="camelCase")]
+pub enum RunningState {
+    KickOff(TeamColor),
+    Penalty,
+    FreeKick,
+    Run
 }

--- a/crates/crabe_framework/src/data/world/team.rs
+++ b/crates/crabe_framework/src/data/world/team.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// The `TeamColor` enum represents the color of a team in the SSL game, either blue or yellow.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum TeamColor {
     Blue,


### PR DESCRIPTION
# Description & content
This PR ensures we are adding most of the features that we had during RoboCup 2023 back into the `main` branch, to have a 
proper starting point for the next competition in 2024.

Features are extracted from [rbc-last-match](/NAMeC-SSL/CRAbE/tree/rbc-last-match). It mostly serves as a re-collection of small commits representing each feature re-implemented. Whether the pull request is accepted or not is not important, but helps identifying the features we have to merge back into `main`.

Some features have deliberately not been re-implemented as they require a re-design or thorough discussion in the team about the software's architecture, and are listed down below.

Status : <span style="color:green">**IN PROGRESS**</span>

## Features identified but not yet added back into `main`

### GameManager and strategies
- File `crabe_decision/src/manager/game_manager.rs`
- Folder `crabe_decision/src/strategy/`

The decision pipeline cannot switch from one strategy to another as we had identified during the competition. This led to "hacksy" ways of changing the strategy which would not be suitable on the long-term.