### PR TITLE
Reimplementing features from RoboCup 2023

### DIFF
--- a/crates/crabe/src/main.rs
+++ b/crates/crabe/src/main.rs
@@ -18,7 +18,8 @@ use env_logger::Env;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
+use log::info;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -137,6 +138,7 @@ impl System {
         let mut feedback: FeedbackMap = Default::default();
 
         while self.running.load(Ordering::SeqCst) {
+            let timer = Instant::now();
             let receive_data = self.input_component.step(&mut feedback);
             self.filter_component.step(receive_data, &mut self.world);
             let (mut command_map, mut tool_data) = self.decision_component.step(&self.world);
@@ -145,7 +147,14 @@ impl System {
             self.guard_component
                 .step(&mut self.world, &mut command_map, &mut ToolCommands);
             feedback = self.output_component.step(command_map, ToolCommands);
-            thread::sleep(_refresh_rate);
+            // info!("Execution time : {} μs", &timer.elapsed().as_micros());
+            let elapsed = timer.elapsed();
+            let mut sleep_time = _refresh_rate;
+            if elapsed <= _refresh_rate {
+                sleep_time = Duration::from(_refresh_rate - timer.elapsed());
+            }
+            thread::sleep(sleep_time);
+            // info!("Actual refresh time : {} μs", &timer.elapsed().as_micros());
         }
     }
 

--- a/crates/crabe_decision/src/action.rs
+++ b/crates/crabe_decision/src/action.rs
@@ -74,6 +74,13 @@ impl ActionWrapper {
         }
     }
 
+    /// Clears the sequence of actions to be executed of all robot.
+    pub fn clear(&mut self) {
+        self.actions.iter_mut().for_each(|(_, sequencer)| {
+            sequencer.clear();
+        })
+    }
+
     /// Computes the sequence of actions to be executed for each robot and returns a
     /// `CommandMap` containing the commands to be sent to each robot.
     ///

--- a/crates/crabe_decision/src/strategy.rs
+++ b/crates/crabe_decision/src/strategy.rs
@@ -12,6 +12,10 @@ pub mod testing;
 /// through an `ActionWrapper` instance. A strategy can run for multiple time steps, until it decides to
 /// terminate by returning `true` from the `step` method.
 pub trait Strategy {
+
+    /// Name of the strategy, that we use as simple reference
+    fn name(&self) -> &'static str;
+
     /// Executes one step of the strategy, updating the state of the robot and issuing commands
     /// to it through the given `ActionWrapper`.
     ///

--- a/crates/crabe_decision/src/strategy/testing/square.rs
+++ b/crates/crabe_decision/src/strategy/testing/square.rs
@@ -22,6 +22,11 @@ impl Square {
 }
 
 impl Strategy for Square {
+
+    fn name(&self) -> &'static str {
+        "Square"
+    }
+
     /// Executes the Square strategy.
     ///
     /// This strategy commands the robot with the specified ID to move in a square shape in a

--- a/crates/crabe_filter/src/data.rs
+++ b/crates/crabe_filter/src/data.rs
@@ -21,7 +21,7 @@ pub type TrackedRobotMap<T> = HashMap<u8, TrackedRobot<T>>;
 pub struct FilterData {
     pub allies: TrackedRobotMap<AllyInfo>,
     pub enemies: TrackedRobotMap<EnemyInfo>,
-    pub ball: TrackedBall,
+    pub ball: Option<TrackedBall>,
     pub geometry: CamGeometry,
 }
 

--- a/crates/crabe_filter/src/filter.rs
+++ b/crates/crabe_filter/src/filter.rs
@@ -1,6 +1,7 @@
 pub mod inactive;
 pub mod passthrough;
 pub mod velocity_acceleration;
+pub mod field_side;
 
 use crate::data::FilterData;
 use crabe_framework::data::world::World;

--- a/crates/crabe_filter/src/filter/field_side.rs
+++ b/crates/crabe_filter/src/filter/field_side.rs
@@ -1,0 +1,41 @@
+use crabe_framework::data::world::{Robot, World};
+use crate::data::{FilterData, TrackedBall, TrackedRobotMap};
+use crate::FieldSide;
+use crate::filter::Filter;
+use crate::post_filter::PostFilter;
+
+pub struct FieldSideFilter {
+    field_side: FieldSide,
+}
+
+impl FieldSideFilter {
+    pub fn new(field_side: FieldSide) -> FieldSideFilter {
+        FieldSideFilter { field_side }
+    }
+
+    fn filter_robots_by_side<T>(tracked_robots: &mut TrackedRobotMap<T>, field_side: &FieldSide) {
+        tracked_robots.retain(|_id, robot| {
+            match field_side {
+                FieldSide::Positive => robot.data.pose.position.x.is_sign_positive(),
+                FieldSide::Negative => robot.data.pose.position.x.is_sign_negative()
+            }
+        });
+    }
+
+    fn filter_ball_by_side(tracked_ball: &mut Option<TrackedBall>, field_side: &FieldSide) {
+        *tracked_ball = tracked_ball.take().filter(|ball| {
+            match field_side {
+                FieldSide::Positive => ball.data.position.x.is_sign_positive(),
+                FieldSide::Negative => ball.data.position.x.is_sign_negative()
+            }
+        })
+    }
+}
+
+impl Filter for FieldSideFilter {
+    fn step(&mut self, filter_data: &mut FilterData, _world: &World) {
+        Self::filter_robots_by_side(&mut filter_data.allies, &self.field_side);
+        Self::filter_robots_by_side(&mut filter_data.enemies, &self.field_side);
+        Self::filter_ball_by_side(&mut filter_data.ball, &self.field_side);
+    }
+}

--- a/crates/crabe_filter/src/filter/passthrough.rs
+++ b/crates/crabe_filter/src/filter/passthrough.rs
@@ -40,6 +40,8 @@ impl Filter for PassthroughFilter {
     fn step(&mut self, filter_data: &mut FilterData, _world: &World) {
         robot_passthrough(filter_data.allies.iter_mut());
         robot_passthrough(filter_data.enemies.iter_mut());
-        ball_passthrough(&mut filter_data.ball);
+
+        let tracked_ball = filter_data.ball.get_or_insert(Default::default());
+        ball_passthrough(tracked_ball);
     }
 }

--- a/crates/crabe_filter/src/filter/velocity_acceleration.rs
+++ b/crates/crabe_filter/src/filter/velocity_acceleration.rs
@@ -47,7 +47,9 @@ impl Filter for VelocityAccelerationFilter {
     fn step(&mut self, filter_data: &mut FilterData, world: &World) {
         update_robot_vel_accel(&mut filter_data.allies, &world.allies_bot);
         if let Some(ball) = world.ball.as_ref() {
-            update_ball_vel_accel(&mut filter_data.ball, ball);
+            if let Some(tracked_ball) = &mut filter_data.ball {
+                update_ball_vel_accel(tracked_ball, ball);
+            }
         }
     }
 }

--- a/crates/crabe_filter/src/lib.rs
+++ b/crates/crabe_filter/src/lib.rs
@@ -15,14 +15,25 @@ use crate::post_filter::robot::RobotFilter;
 use crate::post_filter::PostFilter;
 use crate::pre_filter::vision::VisionFilter;
 use crate::pre_filter::PreFilter;
-use clap::Args;
+use clap::{Args, ValueEnum};
 use crabe_framework::component::{Component, FilterComponent};
 use crabe_framework::config::CommonConfig;
 use crabe_framework::data::input::InboundData;
 use crabe_framework::data::world::{TeamColor, World};
+use filter::velocity_acceleration::VelocityAccelerationFilter;
+use crate::filter::field_side::FieldSideFilter;
 
 #[derive(Args)]
-pub struct FilterConfig {}
+pub struct FilterConfig {
+    #[arg(long)]
+    field_side: Option<FieldSide>
+}
+
+#[derive(Debug, ValueEnum, Clone)]
+pub enum FieldSide {
+    Positive,
+    Negative
+}
 
 pub struct FilterPipeline {
     pub pre_filters: Vec<Box<dyn PreFilter>>,
@@ -33,18 +44,28 @@ pub struct FilterPipeline {
 }
 
 impl FilterPipeline {
-    pub fn with_config(_config: FilterConfig, common_config: &CommonConfig) -> Self {
+    pub fn with_config(config: FilterConfig, common_config: &CommonConfig) -> Self {
+        let mut pre_filters: Vec<Box<dyn PreFilter>> = vec![Box::new(VisionFilter::new())];
+        let mut filters: Vec<Box<dyn Filter>> = vec![
+            Box::new(PassthroughFilter),
+            Box::new(VelocityAccelerationFilter),
+            Box::<InactiveFilter>::default(),
+        ];
+
+        if let Some(field_side) = config.field_side {
+            filters.push(Box::new(FieldSideFilter::new(field_side)))
+        }
+
+        let mut post_filters: Vec<Box<dyn PostFilter>> = vec![
+            Box::new(RobotFilter),
+            Box::new(GeometryFilter),
+            Box::new(BallFilter),
+        ];
+
         Self {
-            pre_filters: vec![Box::new(VisionFilter::new())],
-            filters: vec![
-                Box::new(PassthroughFilter),
-                Box::new(InactiveFilter::default()),
-            ],
-            post_filters: vec![
-                Box::new(RobotFilter),
-                Box::new(GeometryFilter),
-                Box::new(BallFilter),
-            ],
+            pre_filters,
+            filters,
+            post_filters,
             filter_data: FilterData {
                 allies: Default::default(),
                 enemies: Default::default(),

--- a/crates/crabe_filter/src/post_filter/ball.rs
+++ b/crates/crabe_filter/src/post_filter/ball.rs
@@ -6,6 +6,18 @@ pub struct BallFilter;
 
 impl PostFilter for BallFilter {
     fn step(&mut self, filter_data: &FilterData, world: &mut World) {
-        world.ball = Some(filter_data.ball.data.clone());
+        let ball = filter_data.ball.as_ref().map(|tracked_ball| {
+            let mut ball = tracked_ball.data.clone();
+            if world.data.positive_half == world.team_color {
+                ball.position.x = -ball.position.x;
+                ball.position.y = -ball.position.y;
+            }
+
+            ball
+        });
+
+        if ball.is_some() {
+            world.ball = ball;
+        } 
     }
 }

--- a/crates/crabe_filter/src/pre_filter/vision.rs
+++ b/crates/crabe_filter/src/pre_filter/vision.rs
@@ -98,7 +98,7 @@ mod detection {
 
         pub struct BallDetectionInfo<'a> {
             pub detected: &'a [SslDetectionBall],
-            pub tracked: &'a mut TrackedBall,
+            pub tracked: &'a mut Option<TrackedBall>,
         }
 
         pub fn detect_balls(detection: &mut BallDetectionInfo, frame: &FrameInfo) {
@@ -112,7 +112,7 @@ mod detection {
                 confidence: b.confidence as f64,
             });
 
-            detection.tracked.packets.extend(ball_packets);
+            detection.tracked.get_or_insert(Default::default()).packets.extend(ball_packets);
         }
     }
 

--- a/crates/crabe_framework/src/data/world.rs
+++ b/crates/crabe_framework/src/data/world.rs
@@ -12,7 +12,10 @@ mod team;
 pub use self::team::{Team, TeamColor};
 
 mod game_state;
+mod game_data;
+
 pub use self::game_state::GameState;
+pub use self::game_data::GameData;
 
 use crate::config::CommonConfig;
 use crate::data::geometry::Geometry;
@@ -26,7 +29,7 @@ use serde::Serialize;
 #[serde(rename_all = "camelCase")]
 pub struct World {
     /// The current state of the game.
-    pub state: GameState,
+    pub data: GameData,
     /// The geometry of the field, including its dimensions and the positions of goals and other areas.
     pub geometry: Geometry,
     /// A map of all the ally robots in the game, identified by their unique ID.
@@ -50,7 +53,7 @@ impl World {
             TeamColor::Blue
         };
         Self {
-            state: GameState::new(team_color),
+            data: GameData::new(team_color),
             geometry: Default::default(),
             allies_bot: Default::default(),
             enemies_bot: Default::default(),

--- a/crates/crabe_framework/src/data/world/game_data.rs
+++ b/crates/crabe_framework/src/data/world/game_data.rs
@@ -1,0 +1,30 @@
+use crate::data::world::{Team, TeamColor};
+use serde::Serialize;
+use crate::data::world::game_state::{GameState, HaltedState};
+
+/// The `GameData` struct represents the state of the SSL game, including the teams and which team is on the positive half of the field.
+#[derive(Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GameData {
+    /// The `Team` struct representing our ally team.
+    pub ally: Team,
+    /// The `Team` struct representing the enemy team.
+    pub enemy: Team,
+    /// The color of the team that is on the positive half of the field.
+    pub positive_half: TeamColor,
+    /// The current game state
+    pub state: GameState
+}
+
+impl GameData {
+    /// Creates a new `GameData` with the given `team_color` as the team color for the ally team, and the opposite team color for the enemy team.
+    pub fn new(team_color: TeamColor) -> Self {
+        Self {
+            ally: Team::with_color(team_color),
+            enemy: Team::with_color(team_color.opposite()),
+            positive_half: team_color.opposite(),
+            state: GameState::Halted(HaltedState::Halt),
+        }
+    }
+}
+ 

--- a/crates/crabe_framework/src/data/world/game_state.rs
+++ b/crates/crabe_framework/src/data/world/game_state.rs
@@ -1,25 +1,35 @@
-use crate::data::world::{Team, TeamColor};
 use serde::Serialize;
+use crate::data::world::TeamColor;
 
-/// The `GameState` struct represents the state of the SSL game, including the teams and which team is on the positive half of the field.
-#[derive(Serialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct GameState {
-    /// The `Team` struct representing our ally team.
-    pub ally: Team,
-    /// The `Team` struct representing the enemy team.
-    pub enemy: Team,
-    /// The color of the team that is on the positive half of the field.
-    pub positive_half: TeamColor,
+#[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all="camelCase")]
+pub enum GameState {
+    Halted(HaltedState),
+    Stopped(StoppedState),
+    Running(RunningState)
 }
 
-impl GameState {
-    /// Creates a new `GameState` with the given `team_color` as the team color for the ally team, and the opposite team color for the enemy team.
-    pub fn new(team_color: TeamColor) -> Self {
-        Self {
-            ally: Team::with_color(team_color),
-            enemy: Team::with_color(team_color.opposite()),
-            positive_half: team_color.opposite(),
-        }
-    }
+#[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all="camelCase")]
+pub enum HaltedState {
+    Halt,
+    Timeout
+}
+
+#[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all="camelCase")]
+pub enum StoppedState {
+    Stop,
+    PrepareKickoff,
+    PreparePenalty,
+    BallPlacement
+}
+
+#[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all="camelCase")]
+pub enum RunningState {
+    KickOff(TeamColor),
+    Penalty,
+    FreeKick,
+    Run
 }

--- a/crates/crabe_framework/src/data/world/game_state.rs
+++ b/crates/crabe_framework/src/data/world/game_state.rs
@@ -20,16 +20,16 @@ pub enum HaltedState {
 #[serde(rename_all="camelCase")]
 pub enum StoppedState {
     Stop,
-    PrepareKickoff,
-    PreparePenalty,
-    BallPlacement
+    PrepareKickoff(TeamColor),
+    PreparePenalty(TeamColor),
+    BallPlacement(TeamColor)
 }
 
 #[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
 #[serde(rename_all="camelCase")]
 pub enum RunningState {
     KickOff(TeamColor),
-    Penalty,
-    FreeKick,
+    Penalty(TeamColor),
+    FreeKick(TeamColor),
     Run
 }

--- a/crates/crabe_framework/src/data/world/robot.rs
+++ b/crates/crabe_framework/src/data/world/robot.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use nalgebra::{Point2, Vector2};
+use nalgebra::{distance, Point2, Vector2};
 use serde::Serialize;
 use std::collections::HashMap;
 
@@ -73,6 +73,18 @@ pub struct Robot<T> {
     pub acceleration: RobotAcceleration,
     /// The timestamp indicating when this information was last updated.
     pub timestamp: DateTime<Utc>,
+}
+
+impl<T> Robot<T> {
+    /// Returns the distance from the center of this robot's position
+    /// to the given Point2 object
+    /// # Args
+    /// - point: The point to measure the distance of this robot to
+    /// # Notes
+    /// Is just a shorthand to use the nalgebra distance() function on robots
+    pub fn distance(&self, point: &Point2<f64>) -> f64 {
+        distance(&self.pose.position, point)
+    }
 }
 
 impl<T: Clone> Clone for Robot<T> {

--- a/crates/crabe_framework/src/data/world/team.rs
+++ b/crates/crabe_framework/src/data/world/team.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// The `TeamColor` enum represents the color of a team in the SSL game, either blue or yellow.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum TeamColor {
     Blue,

--- a/crates/crabe_io/src/league/game_controller/game_controller_thread.rs
+++ b/crates/crabe_io/src/league/game_controller/game_controller_thread.rs
@@ -25,7 +25,7 @@ impl GameController {
         let ipv4 = Ipv4Addr::from_str(cli.gc_ip.as_str())
             .expect("Failed to create an ipv4 address with the ip");
         let mut gc =
-            MulticastUDPReceiver::new(ipv4, cli.gc_port).expect("Failed to create vision receiver");
+            MulticastUDPReceiver::new(ipv4, cli.gc_port).expect("Failed to create GC receiver");
         let running = Arc::new(AtomicBool::new(true));
         let running_clone = Arc::clone(&running);
 


### PR DESCRIPTION
# Description & content
This PR ensures we are adding most of the features that we had during RoboCup 2023 back into the `main` branch, to have a 
proper starting point for the next competition in 2024.

Features are extracted from [rbc-last-match](/NAMeC-SSL/CRAbE/tree/rbc-last-match). It mostly serves as a re-collection of small commits representing each feature re-implemented. Whether the pull request is accepted or not is not important, but helps identifying the features we have to merge back into `main`.

Some features have deliberately not been re-implemented as they require a re-design or thorough discussion in the team about the software's architecture, and are listed down below.

Status : <span style="color:green">**FINISHED**</span>

## Features identified but not yet added back into `main`

### GameManager and strategies
- File `crabe_decision/src/manager/game_manager.rs`
- Folder `crabe_decision/src/strategy/`

The decision pipeline cannot switch from one strategy to another as we had identified during the competition. This led to "hacksy" ways of changing the strategy which would not be suitable on the long-term.

### State machine (GameController Pre/Post filters)
I don't have enough knowledge on my own to judge whether what we had was valid or not, I'd like to let someone handle it for me.

### Modify MoveTo command + Obstacle avoidance
We have to delve deeper into the high-level command and the actual movement of the robot that happens in its embedded software. Also, setting a given initialization signature for the MoveTo command (`MoveTo::new()`) would help us not having to crawl in the whole codebase to modify any call to it when MoveTo receives a change.

### Receive filtered data from AutoRefs
Related pull request :
- #33

AutoReferees now publish filtered data from the vision, such as robot speed and acceleration.
Was not implemented in the end during the competition, but could make a huge difference in our decision-taking and algorithms.

### Negative coordinates always point towards our side of the field
IIRC @Jossl123 implemented a filter and something else that would affect the coordinates. This would mean that sending a robot to positive coordinates would put the robot in the enemy's side of the field.  
Haven't identified yet which commits and PRs are related to it.

### Whatever resides in `crabe_filter/src/pre_filter/*`
never worked on the filters before so I need help figuring it out  
you can check for yourself using the following command
```bash
git checkout feats-from-rbc
git diff rbc-last-match crates/crabe_filter/src/pre_filter/*
```
Note that this will not display the files that were added on the target branch.

### Data about the goal coordinates
Related commit :
- d68191b91ebdc6921b3b521ed3a2157ab32cbcfa

### More points about goal area
Related commits : 
- 21c34976013976e0c52c39d152efe1e5c197f583
- d68191b91ebdc6921b3b521ed3a2157ab32cbcfa
Instead of only top-left and bottom-right, you get more points like bottom-left and center.

### Everything in `crabe_math`
Didn't write the functions nor the tests, so I'll let it to ya

### Move `gc` option to common config
Related commit :
- 964ede4af2bb68d52e32a29a81561e1aabc01468
@EtienneSchmitz it's yours, not sure about its importance so I'll leave it to you

## Features being added
Note that not all features will be explained below (because I was too lazy at first and wrote it in the commit message instead)

### [Done] Improve refresh rate precision
Related commit and PR:
- #68
- 634f1fe655faf3846fd8e923f42af94577a7ac68

### [Done] Filter one specific side of the field
Related pull requests :
- #11
- #21 (specifically 220714e5798e027adfd8fb4c041942b442a77594)
- #25 