### PR TITLE
reimpl: ability to clear actions of ActionWrapper for all robots

### DIFF
--- a/crates/crabe_decision/src/action.rs
+++ b/crates/crabe_decision/src/action.rs
@@ -74,6 +74,13 @@ impl ActionWrapper {
         }
     }
 
+    /// Clears the sequence of actions to be executed of all robot.
+    pub fn clear(&mut self) {
+        self.actions.iter_mut().for_each(|(_, sequencer)| {
+            sequencer.clear();
+        })
+    }
+
     /// Computes the sequence of actions to be executed for each robot and returns a
     /// `CommandMap` containing the commands to be sent to each robot.
     ///

--- a/crates/crabe_decision/src/action.rs
+++ b/crates/crabe_decision/src/action.rs
@@ -76,8 +76,8 @@ impl ActionWrapper {
 
     /// Clears the sequence of actions to be executed of all robot.
     pub fn clear_all(&mut self) {
-        self.actions.iter_mut().for_each(|(_, sequencer)| {
-            sequencer.clear();
+        self.actions.for_each(|(_, action)| {
+            action.clear();
         })
     }
 

--- a/crates/crabe_decision/src/action.rs
+++ b/crates/crabe_decision/src/action.rs
@@ -68,14 +68,14 @@ impl ActionWrapper {
     /// # Arguments
     ///
     /// * `id`: The id of the robot whose sequence of actions will be cleared.
-    pub fn clean(&mut self, id: u8) {
+    pub fn clear(&mut self, id: u8) {
         if let Some(sequencer) = self.actions.get_mut(&id) {
             sequencer.clear();
         }
     }
 
     /// Clears the sequence of actions to be executed of all robot.
-    pub fn clear(&mut self) {
+    pub fn clear_all(&mut self) {
         self.actions.iter_mut().for_each(|(_, sequencer)| {
             sequencer.clear();
         })


### PR DESCRIPTION
Feature to re-implement, that was already committed in #75 