### PR TITLE
feat: strategies must have a name

### DIFF
--- a/crates/crabe_decision/src/strategy.rs
+++ b/crates/crabe_decision/src/strategy.rs
@@ -12,6 +12,10 @@ pub mod testing;
 /// through an `ActionWrapper` instance. A strategy can run for multiple time steps, until it decides to
 /// terminate by returning `true` from the `step` method.
 pub trait Strategy {
+
+    /// Name of the strategy, that we use as simple reference
+    fn name(&self) -> &'static str;
+
     /// Executes one step of the strategy, updating the state of the robot and issuing commands
     /// to it through the given `ActionWrapper`.
     ///

--- a/crates/crabe_decision/src/strategy/testing/square.rs
+++ b/crates/crabe_decision/src/strategy/testing/square.rs
@@ -22,6 +22,11 @@ impl Square {
 }
 
 impl Strategy for Square {
+
+    fn name(&self) -> &'static str {
+        "Square"
+    }
+
     /// Executes the Square strategy.
     ///
     /// This strategy commands the robot with the specified ID to move in a square shape in a


### PR DESCRIPTION
The public trait 'Strategy' has a new `name()` method that must return a `&'static str`
Comes from #75 