### PR TITLE
feat: add game data and change role of GameState

### DIFF
--- a/crates/crabe_framework/src/data/world.rs
+++ b/crates/crabe_framework/src/data/world.rs
@@ -12,7 +12,10 @@ mod team;
 pub use self::team::{Team, TeamColor};
 
 mod game_state;
+mod game_data;
+
 pub use self::game_state::GameState;
+pub use self::game_data::GameData;
 
 use crate::config::CommonConfig;
 use crate::data::geometry::Geometry;
@@ -26,7 +29,7 @@ use serde::Serialize;
 #[serde(rename_all = "camelCase")]
 pub struct World {
     /// The current state of the game.
-    pub state: GameState,
+    pub data: GameData,
     /// The geometry of the field, including its dimensions and the positions of goals and other areas.
     pub geometry: Geometry,
     /// A map of all the ally robots in the game, identified by their unique ID.
@@ -50,7 +53,7 @@ impl World {
             TeamColor::Blue
         };
         Self {
-            state: GameState::new(team_color),
+            data: GameData::new(team_color),
             geometry: Default::default(),
             allies_bot: Default::default(),
             enemies_bot: Default::default(),

--- a/crates/crabe_framework/src/data/world/game_data.rs
+++ b/crates/crabe_framework/src/data/world/game_data.rs
@@ -1,0 +1,30 @@
+use crate::data::world::{Team, TeamColor};
+use serde::Serialize;
+use crate::data::world::game_state::{GameState, HaltedState};
+
+/// The `GameData` struct represents the state of the SSL game, including the teams and which team is on the positive half of the field.
+#[derive(Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GameData {
+    /// The `Team` struct representing our ally team.
+    pub ally: Team,
+    /// The `Team` struct representing the enemy team.
+    pub enemy: Team,
+    /// The color of the team that is on the positive half of the field.
+    pub positive_half: TeamColor,
+    /// The current game state
+    pub state: GameState
+}
+
+impl GameData {
+    /// Creates a new `GameData` with the given `team_color` as the team color for the ally team, and the opposite team color for the enemy team.
+    pub fn new(team_color: TeamColor) -> Self {
+        Self {
+            ally: Team::with_color(team_color),
+            enemy: Team::with_color(team_color.opposite()),
+            positive_half: team_color.opposite(),
+            state: GameState::Halted(HaltedState::Halt),
+        }
+    }
+}
+ 

--- a/crates/crabe_framework/src/data/world/game_state.rs
+++ b/crates/crabe_framework/src/data/world/game_state.rs
@@ -1,25 +1,35 @@
-use crate::data::world::{Team, TeamColor};
 use serde::Serialize;
+use crate::data::world::TeamColor;
 
-/// The `GameState` struct represents the state of the SSL game, including the teams and which team is on the positive half of the field.
-#[derive(Serialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct GameState {
-    /// The `Team` struct representing our ally team.
-    pub ally: Team,
-    /// The `Team` struct representing the enemy team.
-    pub enemy: Team,
-    /// The color of the team that is on the positive half of the field.
-    pub positive_half: TeamColor,
+#[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all="camelCase")]
+pub enum GameState {
+    Halted(HaltedState),
+    Stopped(StoppedState),
+    Running(RunningState)
 }
 
-impl GameState {
-    /// Creates a new `GameState` with the given `team_color` as the team color for the ally team, and the opposite team color for the enemy team.
-    pub fn new(team_color: TeamColor) -> Self {
-        Self {
-            ally: Team::with_color(team_color),
-            enemy: Team::with_color(team_color.opposite()),
-            positive_half: team_color.opposite(),
-        }
-    }
+#[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all="camelCase")]
+pub enum HaltedState {
+    Halt,
+    Timeout
+}
+
+#[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all="camelCase")]
+pub enum StoppedState {
+    Stop,
+    PrepareKickoff,
+    PreparePenalty,
+    BallPlacement
+}
+
+#[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all="camelCase")]
+pub enum RunningState {
+    KickOff(TeamColor),
+    Penalty,
+    FreeKick,
+    Run
 }

--- a/crates/crabe_framework/src/data/world/team.rs
+++ b/crates/crabe_framework/src/data/world/team.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// The `TeamColor` enum represents the color of a team in the SSL game, either blue or yellow.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum TeamColor {
     Blue,


### PR DESCRIPTION
Cherry-picked from commit hash 8bf21400e6f7e4f8f355761c0670e9bbe2590e9f

This changes the role of GameState to instead represent the current state as decided by the external game controller (such as when the game is halted, see the [SSL rulebook](https://ssl.robocup.org/rules/), appendix B Game States).

GameData will instead hold information about ally and enemy team, color of the team on the positive half, and the current GameState.

From #75 