### PR TITLE
fix: typo, replace 'vision' by 'GC' in err message when creating GC

### DIFF
--- a/crates/crabe_io/src/league/game_controller/game_controller_thread.rs
+++ b/crates/crabe_io/src/league/game_controller/game_controller_thread.rs
@@ -25,7 +25,7 @@ impl GameController {
         let ipv4 = Ipv4Addr::from_str(cli.gc_ip.as_str())
             .expect("Failed to create an ipv4 address with the ip");
         let mut gc =
-            MulticastUDPReceiver::new(ipv4, cli.gc_port).expect("Failed to create vision receiver");
+            MulticastUDPReceiver::new(ipv4, cli.gc_port).expect("Failed to create GC receiver");
         let running = Arc::new(AtomicBool::new(true));
         let running_clone = Arc::clone(&running);
 


### PR DESCRIPTION
...eceiver

this is just a typo, just accept it :cake: 

Extracted from commit fb65172462d23cde41091101712fb4a6187402cb
From #75 