### PR TITLE
Game Controller filter

### DIFF
--- a/crates/crabe_filter/src/data.rs
+++ b/crates/crabe_filter/src/data.rs
@@ -8,6 +8,7 @@ use crabe_framework::data::world::{AllyInfo, Ball, EnemyInfo, Robot};
 use ringbuffer::ConstGenericRingBuffer;
 use std::collections::HashMap;
 use std::time::Instant;
+use crate::data::referee::Referee;
 
 #[derive(Clone, Debug)]
 pub struct FrameInfo {
@@ -16,6 +17,8 @@ pub struct FrameInfo {
     pub t_capture: DateTime<Utc>,
 }
 
+pub mod referee;
+
 pub type TrackedRobotMap<T> = HashMap<u8, TrackedRobot<T>>;
 
 pub struct FilterData {
@@ -23,6 +26,7 @@ pub struct FilterData {
     pub enemies: TrackedRobotMap<EnemyInfo>,
     pub ball: TrackedBall,
     pub geometry: CamGeometry,
+    pub referee: Vec<Referee>,
 }
 
 pub struct TrackedRobot<T> {

--- a/crates/crabe_filter/src/data/referee.rs
+++ b/crates/crabe_filter/src/data/referee.rs
@@ -1,0 +1,186 @@
+use chrono::{DateTime, Duration, Utc};
+use crabe_framework::data::world::TeamColor;
+use event::GameEvent;
+use nalgebra::Point2;
+
+pub mod event;
+
+/// MatchType is a meta information about the current match for easier log processing.
+#[derive(
+Clone,
+Copy,
+Debug
+)]
+#[repr(i32)]
+pub enum MatchType {
+    /// Not set
+    UnknownMatch = 0,
+    /// Match is part of the group phase
+    GroupPhase = 1,
+    /// Match is part of the elimination phase
+    EliminationPhase = 2,
+    /// Friendly match, not part of a tournament
+    Friendly = 3,
+}
+
+/// The `Referee` struct contains various information about the referee of a match.
+#[derive(Clone, Debug)]
+pub struct Referee {
+    /// A random UUID of the referee that is kept constant while running.
+    pub source_identifier: Option<String>,
+    /// Meta information about the current match that helps to process the logs after a competition.
+    pub match_type: Option<MatchType>,
+    /// The UNIX timestamp when the packet was sent, in microseconds.
+    pub packet_timestamp: DateTime<Utc>,
+    /// Represent the "coarse" stages of the match.
+    pub stage: Stage,
+    /// The number of microseconds left in the stage.
+    /// Some stage have this value :
+    /// - NORMAL_FIRST_HALF, NORMAL_HALF_TIME, NORMAL_SECOND_HALF
+    /// - EXTRA_TIME_BREAK EXTRA_FIRST_HALF EXTRA_HALF_TIME EXTRA_SECOND_HALF
+    /// - PENALTY_SHOOTOUT_BREAK
+    /// If the stage runs over its specified time, this value becomes negative.
+    pub stage_time_left: Option<Duration>,
+    /// These are the "fine" states of play on the field..
+    pub command: RefereeCommand,
+    /// The number of commands issued since startup (mod 2^32).
+    pub command_counter: u32,
+    /// The UNIX timestamp when the command was issued, in microseconds.
+    pub command_timestamp: DateTime<Utc>,
+    /// Information about the ally team.
+    pub ally: TeamInfo,
+    /// Information about the enemy team.
+    pub enemy: TeamInfo,
+    /// The coordinates of the designated Position (in millimeters).
+    /// Use only in the case of a ball placement command.
+    pub designated_position: Option<Point2<f64>>,
+    /// Information about the direction of play.
+    /// True, if the blue team will have it's goal on the positive x-axis of the ssl-vision coordinate system.
+    /// Obviously, the yellow team will play on the opposite half.
+    pub positive_half: Option<TeamColor>,
+    /// The command that will be issued after the current stoppage and ball placement to continue the game.
+    pub next_command: Option<RefereeCommand>,
+    /// All game events that were detected since the last RUNNING state.
+    /// Will be cleared as soon as the game is continued.
+    pub game_events: Vec<GameEvent>,
+    /// All non-finished proposed game events that may be processed next.
+    pub game_event_proposals: Vec<GameEventProposalGroup>,
+    /// The time in microseconds that is remaining until the current action times out
+    /// The time will not be reset. It can get negative.
+    /// Possible actions where this time is relevant:
+    /// - free kicks
+    /// - kickoff, penalty kick, force start
+    /// - ball placement
+    pub current_action_time_remaining: Option<Duration>,
+}
+
+/// List of matching proposals.
+#[derive(Clone, Debug)]
+pub struct GameEventProposalGroup {
+    /// The proposed game event.
+    pub game_event: Vec<GameEvent>,
+    /// Whether the proposal group was accepted.
+    pub accepted: Option<bool>,
+}
+/// `Stage` represents different stages of a game.
+#[derive(Clone, Debug)]
+#[repr(i32)]
+pub enum Stage {
+    /// Indicates that the first half is about to start.
+    NormalFirstHalfPre = 0,
+    /// Indicates the first half of the normal game, before half time.
+    NormalFirstHalf = 1,
+    /// Indicates the half time period between the first and second halves.
+    NormalHalfTime = 2,
+    /// Indicates that the second half is about to start.
+    NormalSecondHalfPre = 3,
+    /// Indicates the second half of the normal game, after half time.
+    NormalSecondHalf = 4,
+    /// Represents the break before extra time.
+    ExtraTimeBreak = 5,
+    /// Indicates that the first half of the extra time is about to start.
+    ExtraFirstHalfPre = 6,
+    /// Represents the first half of the extra time.
+    ExtraFirstHalf = 7,
+    /// Indicates the half time period between the first and second extra halves.
+    ExtraHalfTime = 8,
+    /// Indicates that the second half of extra time is about to start.
+    ExtraSecondHalfPre = 9,
+    /// Represents the second half of the extra time.
+    ExtraSecondHalf = 10,
+    /// Represents the break period before the penalty shootout.
+    PenaltyShootoutBreak = 11,
+    /// Represents the penalty shootout stage.
+    PenaltyShootout = 12,
+    /// Indicates that the game has ended.
+    PostGame = 13,
+}
+
+/// The `RefereeCommand` enum represents a set of possible commands that a referee can issue during a game.
+/// These commands control the state of the game and dictate the actions that robots are allowed to perform at any given moment.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RefereeCommand {
+    /// Command indicating that all robots must halt movement immediately.
+    Halt,
+    /// Command instructing robots to maintain a distance of at least 50 cm from the ball.
+    Stop,
+    /// Command allowing a team to proceed with a prepared kickoff or penalty shot.
+    NormalStart,
+    /// Command declaring that the ball is freely accessible to any team, typically after a halt.
+    ForceStart,
+    /// Command allowing the specified team to move into position for a kickoff.
+    PrepareKickoff(TeamColor),
+    /// Command allowing the specified team to move into position for a penalty shot.
+    PreparePenalty(TeamColor),
+    /// Command allowing the specified team to take a direct free kick.
+    DirectFree(TeamColor),
+    /// Command allowing the specified team to take an indirect free kick.
+    IndirectFree(TeamColor),
+    /// Command indicating that the specified team has requested a timeout.
+    Timeout(TeamColor),
+    /// Deprecated: This command indicates the specified team has scored a goal.
+    /// It's recommended to use the score field from the team infos instead for goal detection and revoked goals.
+    Goal(TeamColor),
+    /// Command equivalent to `Stop`, but the specified team must retrieve the ball and place it in a designated position.
+    BallPlacement(TeamColor),
+    ///Deprecated state
+    Deprecated,
+}
+
+/// Information about a single team.
+#[derive(Clone, Debug)]
+pub struct TeamInfo {
+    /// The team's name (empty string if operator has not typed anything).
+    pub name: String,
+    /// The number of goals scored by the team during normal play and overtime.
+    pub score: u32,
+    /// The number of red cards issued to the team since the beginning of the game.
+    pub red_cards: u32,
+    /// The amount of time (in microseconds) left on each yellow card issued to the team.
+    /// If no yellow cards are issued, this array has no elements.
+    /// Otherwise, times are ordered from smallest to largest.
+    pub yellow_card_times: Vec<u32>,
+    /// The total number of yellow cards ever issued to the team.
+    pub yellow_cards: u32,
+    /// The number of timeouts this team can still call.
+    /// If in a timeout right now, that timeout is excluded.
+    pub timeouts: u32,
+    /// The number of microseconds of timeout this team can use.
+    pub timeout_time: u32,
+    /// The pattern number of this team's goalkeeper.
+    pub goalkeeper: u32,
+    /// The total number of countable fouls that act towards yellow cards
+    pub foul_counter: Option<u32>,
+    /// The number of consecutive ball placement failures of this team
+    pub ball_placement_failures: Option<u32>,
+    /// Indicate if the team is able and allowed to place the ball
+    pub can_place_ball: Option<bool>,
+    /// The maximum number of bots allowed on the field based on division and cards
+    pub max_allowed_bots: Option<u32>,
+    /// The team has submitted an intent to substitute one or more robots at the next chance
+    pub bot_substitution_intent: Option<bool>,
+    /// Indicate if the team reached the maximum allowed ball placement failures and is thus not allowed to place the ball anymore
+    pub ball_placement_failures_reached: Option<bool>,
+    /// The team is allowed to substitute one or more robots currently
+    pub bot_substitution_allowed: Option<bool>,
+}

--- a/crates/crabe_filter/src/data/referee/event.rs
+++ b/crates/crabe_filter/src/data/referee/event.rs
@@ -1,0 +1,539 @@
+use chrono::Duration;
+use crabe_framework::data::world::TeamColor;
+use crabe_protocol::protobuf::game_controller_packet;
+use crabe_protocol::protobuf::game_controller_packet::game_event::Type;
+use nalgebra::Point2;
+
+/// GameEvent contains exactly one game event.
+/// Each game event has optional and required fields.
+#[derive(Clone, Debug)]
+pub struct GameEvent {
+    /// Event type of this Game
+    pub type_event: Option<GameEventType>,
+    /// The origins of this game event.
+    /// Empty, if it originates from game controller.
+    pub origin: Vec<EventOrigin>,
+    /// Unix timestamp in microseconds when the event was created.
+    pub created_timestamp: Option<u64>,
+    /// the event that occurred
+    pub event: Event,
+}
+
+impl From<game_controller_packet::GameEvent> for GameEvent {
+    fn from(packet: game_controller_packet::GameEvent) -> Self {
+        Self {
+            type_event: Option::from(GameEventType::from(packet.r#type())),
+            origin: vec![],
+            created_timestamp: None,
+            event: Event::DeprecatedEvent,
+        }
+    }
+}
+
+/// All game event type.
+/// See the protobuf message inside the crate `crabe_protocol` to see which game event is triggered by gc, auto_referee and human.
+#[derive(Clone, Debug)]
+pub enum GameEventType {
+    Unknown,
+    BallLeftFieldTouchLine,
+    BallLeftFieldGoalLine,
+    AimlessKick,
+    AttackerTooCloseToDefenseArea,
+    DefenderInDefenseArea,
+    BoundaryCrossing,
+    KeeperHeldBall,
+    BotDribbledBallTooFar,
+    BotPushedBot,
+    BotHeldBallDeliberately,
+    BotTippedOver,
+    AttackerTouchedBallInDefenseArea,
+    BotKickedBallTooFast,
+    BotCrashUnique,
+    BotCrashDrawn,
+    DefenderTooCloseToKickPoint,
+    BotTooFastInStop,
+    BotInterferedPlacement,
+    PossibleGoal,
+    Goal,
+    InvalidGoal,
+    AttackerDoubleTouchedBall,
+    PlacementSucceeded,
+    PenaltyKickFailed,
+    NoProgressInGame,
+    PlacementFailed,
+    MultipleCards,
+    MultipleFouls,
+    BotSubstitution,
+    TooManyRobots,
+    ChallengeFlag,
+    ChallengeFlagHandled,
+    EmergencyStop,
+    UnsportingBehaviorMinor,
+    UnsportingBehaviorMajor,
+    Deprecated,
+}
+
+impl From<Type> for GameEventType {
+    fn from(packet: Type) -> Self {
+        match packet {
+            Type::UnknownGameEventType => GameEventType::Unknown,
+            Type::BallLeftFieldTouchLine => GameEventType::BallLeftFieldTouchLine,
+            Type::BallLeftFieldGoalLine => GameEventType::BallLeftFieldGoalLine,
+            Type::AimlessKick => GameEventType::AimlessKick,
+            Type::AttackerTooCloseToDefenseArea => GameEventType::AttackerTooCloseToDefenseArea,
+            Type::DefenderInDefenseArea => GameEventType::DefenderInDefenseArea,
+            Type::BoundaryCrossing => GameEventType::BoundaryCrossing,
+            Type::KeeperHeldBall => GameEventType::KeeperHeldBall,
+            Type::BotDribbledBallTooFar => GameEventType::BotDribbledBallTooFar,
+            Type::BotPushedBot => GameEventType::BotPushedBot,
+            Type::BotHeldBallDeliberately => GameEventType::BotHeldBallDeliberately,
+            Type::BotTippedOver => GameEventType::BotTippedOver,
+            Type::AttackerTouchedBallInDefenseArea => {
+                GameEventType::AttackerTouchedBallInDefenseArea
+            }
+            Type::BotKickedBallTooFast => GameEventType::BotKickedBallTooFast,
+            Type::BotCrashUnique => GameEventType::BotCrashUnique,
+            Type::BotCrashDrawn => GameEventType::BotCrashDrawn,
+            Type::DefenderTooCloseToKickPoint => GameEventType::DefenderTooCloseToKickPoint,
+            Type::BotTooFastInStop => GameEventType::BotTooFastInStop,
+            Type::BotInterferedPlacement => GameEventType::BotInterferedPlacement,
+            Type::PossibleGoal => GameEventType::PossibleGoal,
+            Type::Goal => GameEventType::Goal,
+            Type::InvalidGoal => GameEventType::InvalidGoal,
+            Type::AttackerDoubleTouchedBall => GameEventType::AttackerDoubleTouchedBall,
+            Type::PlacementSucceeded => GameEventType::PlacementSucceeded,
+            Type::PenaltyKickFailed => GameEventType::PenaltyKickFailed,
+            Type::NoProgressInGame => GameEventType::NoProgressInGame,
+            Type::PlacementFailed => GameEventType::PlacementFailed,
+            Type::MultipleCards => GameEventType::MultipleCards,
+            Type::MultipleFouls => GameEventType::MultipleFouls,
+            Type::BotSubstitution => GameEventType::BotSubstitution,
+            Type::TooManyRobots => GameEventType::TooManyRobots,
+            Type::ChallengeFlag => GameEventType::ChallengeFlag,
+            Type::ChallengeFlagHandled => GameEventType::ChallengeFlagHandled,
+            Type::EmergencyStop => GameEventType::EmergencyStop,
+            Type::UnsportingBehaviorMinor => GameEventType::UnsportingBehaviorMinor,
+            Type::UnsportingBehaviorMajor => GameEventType::UnsportingBehaviorMajor,
+            Type::Prepared => GameEventType::Deprecated,
+            Type::IndirectGoal => GameEventType::Deprecated,
+            Type::ChippedGoal => GameEventType::Deprecated,
+            Type::KickTimeout => GameEventType::Deprecated,
+            Type::AttackerTouchedOpponentInDefenseArea => GameEventType::Deprecated,
+            Type::AttackerTouchedOpponentInDefenseAreaSkipped => GameEventType::Deprecated,
+            Type::BotCrashUniqueSkipped => GameEventType::Deprecated,
+            Type::BotPushedBotSkipped => GameEventType::Deprecated,
+            Type::DefenderInDefenseAreaPartially => GameEventType::Deprecated,
+            Type::MultiplePlacementFailures => GameEventType::Deprecated,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum Event {
+    // Ball out of field events (Stopping)
+    BallLeftFieldTouchLine(BallLeftField),
+    BallLeftFieldGoalLine(BallLeftField),
+    AimlessKick(AimlessKick),
+
+    // Stopping fouls
+    AttackerTooCloseToDefenseArea(AttackerTooCloseToDefenseArea),
+    DefenderInDefenseArea(DefenderInDefenseArea),
+    BoundaryCrossing(BoundaryCrossing),
+    KeeperHeldBall(KeeperHeldBall),
+    BotDribbledBallTooFar(BotDribbledBallTooFar),
+
+    BotPushedBot(BotPushedBot),
+    BotHeldBallDeliberately(BotHeldBallDeliberately),
+    BotTippedOver(BotTippedOver),
+
+    // Non-Stopping Fouls
+    AttackerTouchedBallInDefenseArea(AttackerTouchedBallInDefenseArea),
+    BotKickedBallTooFast(BotKickedBallTooFast),
+    BotCrashUnique(BotCrashUnique),
+    BotCrashDrawn(BotCrashDrawn),
+
+    // Fouls while ball out of play
+    DefenderTooCloseToKickPoint(DefenderTooCloseToKickPoint),
+    BotTooFastInStop(BotTooFastInStop),
+    BotInterferedPlacement(BotInterferedPlacement),
+
+    // Scoring goals
+    PossibleGoal(Goal),
+    Goal(Goal),
+    InvalidGoal(Goal),
+
+    // Other events
+    AttackerDoubleTouchedBall(AttackerDoubleTouchedBall),
+    PlacementSucceeded(PlacementSucceeded),
+    PenaltyKickFailed(PenaltyKickFailed),
+
+    NoProgressInGame(NoProgressInGame),
+    PlacementFailed(PlacementFailed),
+    MultipleCards(TeamColor),
+    MultipleFouls(MultipleFouls),
+    TooManyRobots(TooManyRobots),
+    BotSubstitution(TeamColor),
+    ChallengeFlag(TeamColor),
+    EmergencyStop(TeamColor),
+    UnsportingBehaviorMinor(UnsportingBehaviorMinor),
+    UnsportingBehaviorMajor(UnsportingBehaviorMajor),
+
+    DeprecatedEvent,
+}
+
+//////////////////////////////////////////////////////
+//               Event Struct Type                  //
+//////////////////////////////////////////////////////
+
+/// Represents an event where the ball left the field normally.
+#[derive(Clone, Debug)]
+pub struct BallLeftField {
+    /// The team that last touched the ball.
+    pub by_team: TeamColor,
+    /// The bot that last touched the ball.
+    pub by_bot: Option<u32>,
+    /// The location where the ball left the field (in meter).
+    pub location: Option<Point2<f64>>,
+}
+
+/// Represents an event where the ball left the field via goal line and a team committed an aimless kick.
+#[derive(Clone, Debug)]
+pub struct AimlessKick {
+    /// The team that last touched the ball
+    pub by_team: TeamColor,
+    /// The bot that last touched the ball.
+    pub by_bot: Option<u32>,
+    /// The location where the ball left the field (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The location where the ball was last touched (in meter).
+    pub kick_location: Option<Point2<f64>>,
+}
+
+/// Represents an event where an attacking robot is located too close to the opponent's defense area during a stoppage or free kick.
+#[derive(Clone, Debug)]
+pub struct AttackerTooCloseToDefenseArea {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that is too close to the defense area.
+    pub by_bot: Option<u32>,
+    /// The location of the bot (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The distance of the bot to the penalty area (in meter).
+    pub distance: Option<f64>,
+    /// The location of the ball at the moment when this foul occurred (in meter).
+    pub ball_location: Option<Point2<f64>>,
+}
+
+/// Represents an event where a defender other than the keeper was fully located inside its own defense and touched the ball.
+#[derive(Clone, Debug)]
+pub struct DefenderInDefenseArea {
+    /// The team that found guilty
+    pub by_team: TeamColor,
+    /// The bot that is inside the penalty area
+    pub by_bot: Option<u32>,
+    /// The location of the bot (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The distance from bot case to the nearest point outside the defense area (in meter).
+    pub distance: Option<f64>,
+}
+
+/// Represents an event where a robot chipped the ball over the field boundary out of the playing surface.
+#[derive(Clone, Debug)]
+pub struct BoundaryCrossing {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The location of the ball (in meter).
+    pub location: Option<Point2<f64>>,
+}
+
+/// Represents an event where a keeper held the ball in its defense area for too long.
+#[derive(Clone, Debug)]
+pub struct KeeperHeldBall {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The location of the ball (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The duration that the keeper hold the ball (in seconds).
+    pub duration: Option<Duration>,
+}
+
+/// Represents an event where a bot dribbled to ball too far.
+#[derive(Clone, Debug)]
+pub struct BotDribbledBallTooFar {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that dribbled too far.
+    pub by_bot: Option<u32>,
+    /// The location where the dribbling started (in meter).
+    pub start: Option<Point2<f64>>,
+    /// The location where the maximum dribbling distance was reached (in meter).
+    pub end: Option<Point2<f64>>,
+}
+
+/// Represents an event where a bot pushed another bot over a significant distance.
+#[derive(Clone, Debug)]
+pub struct BotPushedBot {
+    /// The team that pushed the other team.
+    pub by_team: TeamColor,
+    /// The bot that pushed the other bot.
+    pub violator: Option<u32>,
+    /// The bot of the opposite team that was pushed.
+    pub victim: Option<u32>,
+    /// The location of the push (center between both bots) (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The pushed distance (in meter).
+    pub pushed_distance: Option<f64>,
+}
+
+/// Represents an event where a bot held the ball for too long.
+#[derive(Clone, Debug)]
+pub struct BotHeldBallDeliberately {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that holds the ball.
+    pub by_bot: Option<u32>,
+    /// The location of the ball (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The duration that the bot hold the ball (in seconds).
+    pub duration: Option<Duration>,
+}
+
+/// Represents an event where a bot tipped over.
+#[derive(Clone, Debug)]
+pub struct BotTippedOver {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that tipped over.
+    pub by_bot: Option<u32>,
+    /// The location of the bot (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The location of the ball at the moment when this foul occurred (in meter).
+    pub ball_location: Option<Point2<f64>>,
+}
+
+/// Represents an event where an attacker touched the ball inside the opponent defense area.
+#[derive(Clone, Debug)]
+pub struct AttackerTouchedBallInDefenseArea {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that is inside the penalty area.
+    pub by_bot: Option<u32>,
+    /// The location of the bot (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The distance that the bot is inside the penalty area (in meter).
+    pub distance: Option<f64>,
+}
+
+/// Represents an event where a bot kicked the ball too fast.
+#[derive(Clone, Debug)]
+pub struct BotKickedBallTooFast {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that kicked too fast.
+    pub by_bot: Option<u32>,
+    /// The location of the ball at the time of the highest speed (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The absolute initial ball speed (kick speed) (in meter per second).
+    pub initial_ball_speed: Option<f64>,
+    /// Was the ball chipped?
+    pub chipped: Option<bool>,
+}
+
+/// Represents an event where two robots crashed into each other and one team was found guilty to due significant speed difference.
+#[derive(Clone, Debug)]
+pub struct BotCrashUnique {
+    /// The team that caused the crash.
+    pub by_team: TeamColor,
+    /// The bot that caused the crash.
+    pub violator: Option<u32>,
+    /// The bot of the opposite team that was involved in the crash.
+    pub victim: Option<u32>,
+    /// The location of the crash (center between both bots) (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The calculated crash speed vector of the two bots (in meter per second).
+    pub crash_speed: Option<f64>,
+    /// The difference of the velocity of the two bots (in meter per second).
+    pub speed_diff: Option<f64>,
+    /// the angle [rad] in the range [0, π] of the bot velocity vectors
+    /// an angle of 0 rad (  0°) means, the bots barely touched each other
+    /// an angle of π rad (180°) means, the bots crashed frontal into each other
+    pub crash_angle: Option<f64>,
+}
+/// Represents an event where two robots crashed into each other with similar speeds
+#[derive(Clone, Debug)]
+pub struct BotCrashDrawn {
+    /// The bot of the yellow team.
+    pub bot_yellow: Option<u32>,
+    /// The bot of the blue team.
+    pub bot_blue: Option<u32>,
+    /// The location of the crash (center between both bots) (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The calculated crash speed of the two bots (in meter per second).
+    pub crash_speed: Option<f64>,
+    /// The difference of the velocity of the two bots (in meter per second).
+    pub speed_diff: Option<f64>,
+    /// the angle [rad] in the range [0, π] of the bot velocity vectors
+    /// an angle of 0 rad (  0°) means, the bots barely touched each other
+    /// an angle of π rad (180°) means, the bots crashed frontal into each other.
+    pub crash_angle: Option<f64>,
+}
+
+/// Represents an event where a bot of the defending team got too close to the kick point during a free kick.
+#[derive(Clone, Debug)]
+pub struct DefenderTooCloseToKickPoint {
+    /// The team that was found guilty.
+    pub by_team: TeamColor,
+    /// The bot that violates the distance to the kick point.
+    pub by_bot: Option<u32>,
+    /// The location of the bot (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The distance from bot to the kick point (including the minimum radius) (in meter).
+    pub distance: Option<f64>,
+}
+
+/// Represents an event where a bot moved too fast while the game was stopped.
+#[derive(Clone, Debug)]
+pub struct BotTooFastInStop {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that was too fast.
+    pub by_bot: Option<u32>,
+    /// The location of the bot (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The bot speed (in meter per second).
+    pub speed: Option<f64>,
+}
+
+/// Represents an event where a bot interfered the ball placement of the other team.
+#[derive(Clone, Debug)]
+pub struct BotInterferedPlacement {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that interfered the placement.
+    pub by_bot: Option<u32>,
+    /// The location of the bot (in meter).
+    pub location: Option<Point2<f64>>,
+}
+
+/// Represents an event where a team shot a goal
+#[derive(Clone, Debug)]
+pub struct Goal {
+    /// The team that scored the goal.
+    pub by_team: TeamColor,
+    /// The team that shot the goal (different from by_team for own goals).
+    pub kicking_team: Option<TeamColor>,
+    /// The bot that shot the goal.
+    pub kicking_bot: Option<u32>,
+    /// The location where the ball entered the goal (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The location where the ball was kicked (for deciding if this was a valid goal) (in meter).
+    pub kick_location: Option<Point2<f64>>,
+    /// The maximum height the ball reached during the goal kick (for deciding if this was a valid goal) (in meter).
+    pub max_ball_height: Option<f64>,
+    /// Number of robots of scoring team when the ball entered the goal (for deciding if this was a valid goal).
+    pub num_bots_by_team: Option<u32>,
+    /// The UNIX timestamp when the scoring team last touched the ball (in microsecond).
+    pub last_touch_by_team: Option<u64>,
+    /// An additional message with e.g. a reason for invalid goals.
+    pub message: Option<String>,
+}
+
+/// Represents an event where an attacker touched the ball multiple times when it was not allowed to.
+#[derive(Clone, Debug)]
+pub struct AttackerDoubleTouchedBall {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that touched the ball twice.
+    pub by_bot: Option<u32>,
+    /// The location of the ball when it was first touched (in meter).
+    pub location: Option<Point2<f64>>,
+}
+
+/// Represents an event where a team successfully placed the ball.
+#[derive(Clone, Debug)]
+pub struct PlacementSucceeded {
+    /// The team that did the placement.
+    pub by_team: TeamColor,
+    /// The time taken for placing the ball (in second).
+    pub time_taken: Option<f64>,
+    /// The distance between placement location and actual ball position (in meter).
+    pub precision: Option<f64>,
+    /// The distance between the initial ball location and the placement position (in meter).
+    pub distance: Option<f64>,
+}
+
+/// Represents an event where the penalty kick failed (by time or by keeper).
+#[derive(Clone, Debug)]
+pub struct PenaltyKickFailed {
+    /// The team that last touched the ball.
+    pub by_team: TeamColor,
+    /// The location of the ball at the moment of this event (in minute).
+    pub location: Option<Point2<f64>>,
+    /// An explanation of the failure.
+    pub reason: Option<String>,
+}
+
+/// Represents an event where game was stuck.
+#[derive(Clone, Debug)]
+pub struct NoProgressInGame {
+    /// The location of the ball.
+    pub location: Option<Point2<f64>>,
+    /// The time that was waited (in second).
+    pub time: Option<Duration>,
+}
+
+/// Represents an event where the ball placement failed.
+#[derive(Clone, Debug)]
+pub struct PlacementFailed {
+    /// The team that failed.
+    pub by_team: TeamColor,
+    /// The remaining distance from ball to placement position (in meter).
+    pub remaining_distance: Option<f64>,
+}
+
+/// Represents an event where a team collected multiple fouls, which results in a yellow card.
+#[derive(Clone, Debug)]
+pub struct MultipleFouls {
+    /// The team that collected multiple fouls.
+    pub by_team: TeamColor,
+    /// The list of game events that caused the multiple fouls.
+    pub caused_game_events: Vec<GameEvent>,
+}
+
+/// Represents an event where a team has too many robots on the field.
+#[derive(Clone, Debug)]
+pub struct TooManyRobots {
+    /// The team that has too many robots.
+    pub by_team: TeamColor,
+    /// Number of robots allowed at the moment.
+    pub num_robots_allowed: Option<u32>,
+    /// Number of robots currently on the field.
+    pub num_robots_on_field: Option<u32>,
+    /// The location of the ball at the moment when this foul occurred (in meter).
+    pub ball_location: Option<Point2<f64>>,
+}
+
+/// Represents an event where a team was found guilty for minor unsporting behavior.
+#[derive(Clone, Debug)]
+pub struct UnsportingBehaviorMinor {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// An explanation of the situation and decision.
+    pub reason: String,
+}
+
+/// Represents an event where a team was found guilty for minor unsporting behavior.
+#[derive(Clone, Debug)]
+pub struct UnsportingBehaviorMajor {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// An explanation of the situation and decision.
+    pub reason: String,
+}
+
+/// Enum that represent the origin of the event.
+#[derive(Clone, Debug)]
+pub enum EventOrigin {
+    GameController,
+    Autorefs(Vec<String>),
+}

--- a/crates/crabe_filter/src/lib.rs
+++ b/crates/crabe_filter/src/lib.rs
@@ -65,10 +65,10 @@ impl Component for FilterPipeline {
 }
 
 impl FilterComponent for FilterPipeline {
-    fn step(&mut self, inbound_data: InboundData, world: &mut World) {
+    fn step(&mut self, mut inbound_data: InboundData, world: &mut World) {
         self.pre_filters
             .iter_mut()
-            .for_each(|f| f.step(&inbound_data, &self.team_color, &mut self.filter_data));
+            .for_each(|f| f.step(&mut inbound_data, &self.team_color, &mut self.filter_data));
 
         self.filters
             .iter_mut()

--- a/crates/crabe_filter/src/lib.rs
+++ b/crates/crabe_filter/src/lib.rs
@@ -50,6 +50,7 @@ impl FilterPipeline {
                 enemies: Default::default(),
                 ball: Default::default(),
                 geometry: Default::default(),
+                referee: Default::default(),
             },
             team_color: if common_config.yellow {
                 TeamColor::Yellow

--- a/crates/crabe_filter/src/post_filter.rs
+++ b/crates/crabe_filter/src/post_filter.rs
@@ -2,6 +2,8 @@ pub mod ball;
 pub mod geometry;
 pub mod robot;
 
+pub mod game_controller;
+
 use crate::data::FilterData;
 use crabe_framework::data::world::World;
 

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -1,0 +1,319 @@
+use crate::data::FilterData;
+use crate::post_filter::PostFilter;
+use crabe_framework::data::world::game_state::{
+    GameState, HaltedState, RunningState, StoppedState,
+};
+use crabe_framework::data::world::{TeamColor, World};
+use log::warn;
+use nalgebra::Point2;
+
+use crate::data::referee::event::{Event, GameEvent};
+use crate::data::referee::RefereeCommand;
+use std::time::Instant;
+
+const FIRST_KICK_OFF: bool = false;
+#[derive(Debug)]
+pub struct GameControllerPostFilter {
+    previous_game_event: Option<GameEvent>,
+    previous_event: Option<Event>,
+    previous_command: RefereeCommand,
+    last_command: RefereeCommand,
+    chrono: Option<Instant>, // TODO: Need to have an option here ?
+    kicked_off_once: bool,
+}
+
+impl Default for GameControllerPostFilter {
+    fn default() -> Self {
+        GameControllerPostFilter {
+            previous_game_event: None,
+            previous_event: None,
+            previous_command: RefereeCommand::Halt,
+            last_command: RefereeCommand::Halt,
+            chrono: Option::from(Instant::now()),
+            kicked_off_once: false,
+        }
+    }
+}
+
+/// Contains all the possible actions that we may be able
+/// to execute from a referee command
+/// The job of these functions is just to change
+/// the current world state according to the command
+/// and the last event that occurred
+impl GameControllerPostFilter {
+    fn fix_yourself(&mut self) {
+        if self.chrono == None {
+            self.chrono = Option::from(Instant::now());
+        }
+    }
+
+    fn halt_state_branch(world: &mut World) {
+        // Halt event, all robots should stop
+        // consider that timeout is equivalent to normal halt
+        world.data.state = GameState::Halted(HaltedState::Halt);
+    }
+
+    fn stop_state_branch(
+        previous_game_event_opt: &Option<&GameEvent>,
+        _previous_command: &RefereeCommand,
+        world: &mut World,
+        _kicked_off_once: &mut bool,
+        mut _chrono: Option<Instant>,
+    ) {
+
+        if let Some(previous_game_event) = previous_game_event_opt {
+            let previous_event = &previous_game_event.event;
+            match previous_event {
+                //Stopped events
+                Event::Goal(goal_infos)=> {
+                    // Goal has been scored, prepare for next kickoff phase
+                    world.data.state = GameState::Stopped(StoppedState::PrepareKickoff(goal_infos.by_team.opposite()));
+                }
+                Event::BallLeftFieldTouchLine(left_field_infos) |
+                Event::BallLeftFieldGoalLine(left_field_infos) => {
+                    world.data.state = GameState::Stopped(StoppedState::BallPlacement(left_field_infos.by_team.opposite()));
+                }
+                Event::NoProgressInGame(_) |
+                Event::AttackerDoubleTouchedBall(_) |
+                Event::AimlessKick(_) |
+                Event::DefenderInDefenseArea(_) |
+                Event::KeeperHeldBall(_) |
+                Event::BoundaryCrossing(_) |
+                Event::BotDribbledBallTooFar(_) |
+                Event::PenaltyKickFailed(_) |
+                Event::AttackerTooCloseToDefenseArea(_) |
+                Event::PlacementFailed(_) |
+                Event::TooManyRobots(_) |
+                Event::InvalidGoal(_) |
+                Event::BotHeldBallDeliberately(_) |
+                Event::UnsportingBehaviorMinor(_) |
+                Event::UnsportingBehaviorMajor(_) |
+                Event::BotPushedBot(_) => {
+                    world.data.state = GameState::Stopped(StoppedState::Stop);
+                }
+                Event::BotTippedOver(infos) => {
+                    // Precaution : stopping robots if there was an accident
+                    // Robot has to be substituted
+                    if infos.by_team.eq(&world.team_color) {
+                        warn!("[IRL ACCIDENT] Robot {}", infos.by_bot.unwrap());
+                    }
+                    world.data.state = GameState::Halted(HaltedState::Halt);
+                }
+
+                //Non stopping fouls
+                Event::AttackerTouchedBallInDefenseArea(_) => {
+                    dbg!("AttackerTouchedBallInDefenseArea");
+                }
+                Event::BotKickedBallTooFast(_) => {
+                    dbg!("BotKickedBallTooFast");
+                }
+                Event::BotCrashUnique(_) => {
+                    dbg!("BotCrashUnique");
+                }
+                Event::BotCrashDrawn(_) |
+                Event::DefenderTooCloseToKickPoint(_) |
+                Event::BotTooFastInStop(_) |
+                Event::BotInterferedPlacement(_) |
+                Event::PossibleGoal(_) |
+                Event::PlacementSucceeded(_) |
+                Event::MultipleCards(_) |
+                Event::MultipleFouls(_) |
+                Event::BotSubstitution(_) |
+                Event::ChallengeFlag(_) |
+                Event::EmergencyStop(_) |
+                Event::DeprecatedEvent => {
+                    world.data.state = GameState::Stopped(StoppedState::Stop);
+                }
+            }
+        } else {
+            let team = if FIRST_KICK_OFF {world.team_color} else {world.team_color.opposite()};
+            world.data.state = GameState::Stopped(StoppedState::PrepareKickoff(team));
+        }
+        _chrono = Some(Instant::now());
+    }
+
+    fn force_start_state_branch(
+        _previous_event_opt: &Option<Event>,
+        _previous_command: RefereeCommand,
+        world: &mut World,
+        mut _chrono: Option<Instant>,
+    ) {
+        world.data.state = GameState::Running(RunningState::Run);
+    }
+
+    fn normal_start_state_branch(
+        previous_event_opt: &Option<Event>,
+        previous_command: RefereeCommand,
+        world: &mut World,
+        mut _chrono: Option<Instant>,
+    ) {
+        _chrono = match _chrono{
+            Some(_) => _chrono,
+            None => Some(Instant::now())
+        };
+        if let Some(chrono) = _chrono {
+            let ball_pos = match world.ball.clone() {
+                None => {
+                    Point2::new(0.0,0.0)
+                }
+                Some(ball) => {
+                    ball.position.xy()
+                }
+            };
+            if previous_command == RefereeCommand::PrepareKickoff(TeamColor::Blue){
+                if chrono.elapsed() >= std::time::Duration::from_secs(10) {
+                    world.data.state = GameState::Running(RunningState::Run);
+                } else {
+                    if ball_pos.x.abs()>0.5 || ball_pos.y.abs()>0.5 {
+                        world.data.state = GameState::Running(RunningState::Run);
+                    } else if world.data.state != GameState::Running(RunningState::Run){
+                        world.data.state = GameState::Running(RunningState::KickOff(TeamColor::Blue));
+                    }
+                }
+                return
+            }
+            else if previous_command == RefereeCommand::PrepareKickoff(TeamColor::Yellow){
+                if chrono.elapsed() >= std::time::Duration::from_secs(10) {
+                    world.data.state = GameState::Running(RunningState::Run);
+                } else {
+                    if ball_pos.x.abs()>0.5 || ball_pos.y.abs()>0.5 {
+                        world.data.state = GameState::Running(RunningState::Run);
+                    } else if world.data.state != GameState::Running(RunningState::Run){
+                        world.data.state = GameState::Running(RunningState::KickOff(TeamColor::Yellow));
+                    }
+                }
+                return
+            }
+        }
+        else if let Some(previous_event) = previous_event_opt {
+            match previous_event {
+                Event::Goal(g) => {
+                    // Kickoff is in progress by a team, place accordingly on your side
+                    // 10s until we go into normal state
+                    if let Some(chrono) = _chrono {
+                        println!("Kickoff in progress ! It lasts for 10s at most");
+                        if chrono.elapsed() > std::time::Duration::from_secs(10) {
+                            world.data.state =
+                                GameState::Running(RunningState::KickOff(g.by_team.opposite()));
+                        }
+                        return
+                    } else {
+                        // start chrono
+                        _chrono = Some(Instant::now());
+                    }
+                }
+
+                &_ => {}
+            }
+        }
+    }
+
+    fn timeout_branch(world: &mut World, _team:TeamColor) {
+        world.data.state = GameState::Halted(HaltedState::Timeout);
+    }
+
+    fn freekick_branch(world: &mut World, mut _chrono_opt: Option<Instant>, team:TeamColor) {
+        if let Some(chrono) = _chrono_opt {
+            if chrono.elapsed() > std::time::Duration::from_secs(10) {
+                // if 10s have passed, game runs normally
+                world.data.state = GameState::Running(RunningState::Run);
+                _chrono_opt = Some(Instant::now());
+            } else {
+                // otherwise, we are still in the FreeKick state
+                world.data.state = GameState::Running(RunningState::FreeKick(team));
+            }
+        }
+    }
+
+    fn prepare_penalty_branch(world: &mut World, mut _chrono_opt: Option<Instant>, team:TeamColor) {
+        //TODO : the penalty comportement is complex, maybe we're missing a penalty RunningState
+        world.data.state = GameState::Stopped(StoppedState::PreparePenalty(team));
+    }
+
+    fn prepare_kickoff_branch(world: &mut World, mut _chrono_opt: Option<Instant>, team: TeamColor) {
+        world.data.state = GameState::Stopped(StoppedState::PrepareKickoff(team));
+    }
+
+    fn ball_placement_branch(world: &mut World,game_controller: &mut GameControllerPostFilter, team:TeamColor) {
+        if let Some(chrono) = game_controller.chrono {
+            // [ALLEMAGNE] chrono check peut être enlevé si pas de ball placement auto
+            if chrono.elapsed() >= std::time::Duration::from_secs(30) {
+                //TODO : when ball placement isn't done in 30 sec, what happen ?
+                world.data.state = GameState::Stopped(StoppedState::BallPlacement(team.opposite()));
+                //world.data.state = GameState::Running(RunningState::Run);
+            } else {
+                world.data.state = GameState::Stopped(StoppedState::BallPlacement(team));
+            }
+        }
+        //reseting the chrono
+        game_controller.fix_yourself();
+    }
+}
+
+impl PostFilter for GameControllerPostFilter {
+    fn step(&mut self, filter_data: &FilterData, world: &mut World) {
+        self.fix_yourself();
+        // grab data
+        let last_referee_packet = match filter_data.referee.last() {
+            None => {
+                return;
+            }
+            Some(r) => r,
+        };
+
+        let ref_command = last_referee_packet.command.clone();
+        //TODO : not sure about the indirect free refCommand
+        //dbg!(&ref_command);
+        match ref_command {
+            RefereeCommand::Halt => GameControllerPostFilter::halt_state_branch(world),
+            RefereeCommand::Deprecated |
+            RefereeCommand::IndirectFree(_) |
+            RefereeCommand::Stop => {
+                GameControllerPostFilter::stop_state_branch(&last_referee_packet.game_events.last(), &self.previous_command, world, &mut self.kicked_off_once, self.chrono,)
+            },
+            RefereeCommand::NormalStart => {
+                GameControllerPostFilter::normal_start_state_branch(&self.previous_event, self.previous_command.clone(), world, self.chrono,)
+            },
+            RefereeCommand::ForceStart => {
+                GameControllerPostFilter::force_start_state_branch(&self.previous_event, self.previous_command.clone(), world, self.chrono,)
+            },
+            RefereeCommand::Timeout(team) => {
+                GameControllerPostFilter::timeout_branch(world, team)
+            }
+            RefereeCommand::DirectFree(team) => {
+                GameControllerPostFilter::freekick_branch(world, self.chrono, team)
+            }
+            RefereeCommand::BallPlacement(team) => {
+                GameControllerPostFilter::ball_placement_branch(world, self, team)
+            }
+            RefereeCommand::PreparePenalty(team) => {
+                GameControllerPostFilter::prepare_penalty_branch(world, self.chrono, team)
+            }
+            RefereeCommand::Goal(team) => {//TODO : It's recommended to use the score field from the team infos instead for goal detection and revoked goals.
+                GameControllerPostFilter::prepare_kickoff_branch(world, self.chrono, team.opposite())
+            }
+            RefereeCommand::PrepareKickoff(team) => {
+                GameControllerPostFilter::prepare_kickoff_branch(world, self.chrono, team)
+            }
+        }
+
+        // Update previous gamestate & event
+        if let Some(previous_game_event) = last_referee_packet.game_events.last() {
+            self.previous_game_event = Option::from(previous_game_event.clone());
+            self.previous_event = Option::from(previous_game_event.event.clone());
+            //todo: don't clone this, specify lifetime
+        }
+        if ref_command != self.last_command{
+            self.previous_command = self.last_command.clone();
+            self.chrono = Option::from(Instant::now());
+        }
+        self.last_command = ref_command.clone();
+
+        //update positive half team
+        if let Some(team_on_positive_half) = last_referee_packet.positive_half {
+            world.data.positive_half = team_on_positive_half
+        }
+
+        //TODO : ally and enemy
+    }
+}

--- a/crates/crabe_filter/src/pre_filter.rs
+++ b/crates/crabe_filter/src/pre_filter.rs
@@ -3,6 +3,8 @@ use crabe_framework::data::input::InboundData;
 use crabe_framework::data::world::TeamColor;
 
 pub mod vision;
+pub mod packet_translation_filter;
+pub mod common;
 
 pub trait PreFilter {
     fn step(

--- a/crates/crabe_filter/src/pre_filter.rs
+++ b/crates/crabe_filter/src/pre_filter.rs
@@ -7,7 +7,7 @@ pub mod vision;
 pub trait PreFilter {
     fn step(
         &mut self,
-        inbound_data: &InboundData,
+        inbound_data: &mut InboundData,
         team_color: &TeamColor,
         filter_data: &mut FilterData,
     );

--- a/crates/crabe_filter/src/pre_filter/common.rs
+++ b/crates/crabe_filter/src/pre_filter/common.rs
@@ -1,0 +1,19 @@
+use chrono::{DateTime, LocalResult, TimeZone, Utc};
+use log::error;
+
+pub fn create_date_time(t_capture: i64) -> DateTime<Utc> {
+    //dbg!(t_capture);
+    match Utc.timestamp_opt(t_capture, 0) {
+        LocalResult::Single(dt) => dt,
+        LocalResult::None => {
+            let now_utc = Utc::now();
+            error!("Invalid timestamp, using current time: {}", now_utc);
+            now_utc
+        }
+        LocalResult::Ambiguous(dt_min, dt_max) => {
+            let dt_midpoint = dt_min + (dt_max - dt_min) / 2;
+            error!("Ambiguous timestamp resolved to midpoint: {}", dt_midpoint);
+            dt_midpoint
+        }
+    }
+}

--- a/crates/crabe_filter/src/pre_filter/packet_translation_filter.rs
+++ b/crates/crabe_filter/src/pre_filter/packet_translation_filter.rs
@@ -1,0 +1,516 @@
+use crate::data::FilterData;
+use crate::pre_filter::common::create_date_time;
+use crate::pre_filter::PreFilter;
+use chrono::Duration;
+use crabe_framework::data::input::InboundData;
+use crabe_framework::data::world::TeamColor;
+use crabe_protocol::protobuf::game_controller_packet;
+use nalgebra::Point2;
+
+use crabe_protocol::protobuf::game_controller_packet::game_event as protocol_event;
+use crabe_protocol::protobuf::game_controller_packet::game_event::{Event as ProtocolEventData, Goal as ProtocolGoal};
+
+use crabe_protocol::protobuf::game_controller_packet::{GameEvent as ProtocolEvent, game_event::Type as ProtocolType, MatchType as ProtocolMatchType, Referee as ProtocolReferee, Vector2 as ProtocolVector2};
+use crabe_protocol::protobuf::game_controller_packet::referee::{Command as ProtocolCommand, Command, Point as ProtocolPoint, Stage as ProtocolStage};
+use crate::data::referee::event::{Event, EventOrigin,AimlessKick, AttackerDoubleTouchedBall, AttackerTooCloseToDefenseArea, AttackerTouchedBallInDefenseArea, BallLeftField, BotCrashDrawn, BotCrashUnique, BotDribbledBallTooFar, BotHeldBallDeliberately, BotInterferedPlacement, BotKickedBallTooFast, BotPushedBot, BotTippedOver, BotTooFastInStop, BoundaryCrossing, DefenderInDefenseArea, DefenderTooCloseToKickPoint, GameEvent, Goal, KeeperHeldBall, MultipleFouls, NoProgressInGame, PenaltyKickFailed, PlacementFailed, PlacementSucceeded, TooManyRobots, UnsportingBehaviorMajor, UnsportingBehaviorMinor, GameEventType};
+
+use crate::data::referee::{GameEventProposalGroup, Referee, RefereeCommand, Stage, TeamInfo, MatchType};
+use crabe_protocol::protobuf::game_controller_packet::Team as ProtocolTeam;
+pub struct ProtocolPacketTranslateFilter;
+
+impl ProtocolPacketTranslateFilter {}
+
+fn to_team_infos(infos: game_controller_packet::referee::TeamInfo) -> TeamInfo {
+    let _infos = TeamInfo {
+        name: infos.name.into(),
+        score: infos.score,
+        red_cards: infos.red_cards,
+        yellow_card_times: infos.yellow_card_times.into(),
+        yellow_cards: infos.yellow_cards,
+        timeouts: infos.timeouts,
+        timeout_time: infos.timeout_time,
+        goalkeeper: infos.goalkeeper,
+        foul_counter: infos.foul_counter,
+        ball_placement_failures: infos.ball_placement_failures,
+        can_place_ball: infos.can_place_ball,
+        max_allowed_bots: infos.max_allowed_bots,
+        bot_substitution_intent: infos.bot_substitution_intent,
+        ball_placement_failures_reached: infos.ball_placement_failures_reached,
+        bot_substitution_allowed: infos.bot_substitution_allowed,
+    };
+    _infos
+}
+
+fn map_match_type(match_type: ProtocolMatchType) -> MatchType {
+    match match_type {
+        ProtocolMatchType::UnknownMatch => MatchType::UnknownMatch,
+        ProtocolMatchType::GroupPhase => MatchType::GroupPhase,
+        ProtocolMatchType::EliminationPhase => MatchType::EliminationPhase,
+        ProtocolMatchType::Friendly => MatchType::Friendly,
+    }
+}
+fn map_stage(stage: ProtocolStage) -> Stage {
+    match stage {
+        ProtocolStage::NormalFirstHalfPre => Stage::NormalFirstHalfPre,
+        ProtocolStage::NormalFirstHalf => Stage::NormalFirstHalf,
+        ProtocolStage::NormalHalfTime => Stage::NormalHalfTime,
+        ProtocolStage::NormalSecondHalfPre => Stage::NormalSecondHalfPre,
+        ProtocolStage::NormalSecondHalf => Stage::NormalSecondHalf,
+        ProtocolStage::ExtraTimeBreak => Stage::ExtraTimeBreak,
+        ProtocolStage::ExtraFirstHalfPre => Stage::ExtraFirstHalfPre,
+        ProtocolStage::ExtraFirstHalf => Stage::ExtraFirstHalf,
+        ProtocolStage::ExtraHalfTime => Stage::ExtraHalfTime,
+        ProtocolStage::ExtraSecondHalfPre => Stage::ExtraSecondHalfPre,
+        ProtocolStage::ExtraSecondHalf => Stage::ExtraSecondHalf,
+        ProtocolStage::PenaltyShootoutBreak => Stage::PenaltyShootoutBreak,
+        ProtocolStage::PenaltyShootout => Stage::PenaltyShootout,
+        ProtocolStage::PostGame => Stage::PostGame,
+    }
+}
+
+fn map_command(incoming: ProtocolCommand) -> RefereeCommand {
+    match incoming {
+        Command::Halt => RefereeCommand::Halt,
+        Command::Stop => RefereeCommand::Stop,
+        Command::NormalStart => RefereeCommand::NormalStart,
+        Command::ForceStart => RefereeCommand::ForceStart,
+        Command::PrepareKickoffYellow => RefereeCommand::PrepareKickoff(TeamColor::Yellow),
+        Command::PrepareKickoffBlue => RefereeCommand::PrepareKickoff(TeamColor::Blue),
+        Command::PreparePenaltyYellow => RefereeCommand::PreparePenalty(TeamColor::Yellow),
+        Command::PreparePenaltyBlue => RefereeCommand::PreparePenalty(TeamColor::Blue),
+        Command::DirectFreeYellow => RefereeCommand::DirectFree(TeamColor::Yellow),
+        Command::DirectFreeBlue => RefereeCommand::DirectFree(TeamColor::Blue),
+        Command::TimeoutYellow => RefereeCommand::Timeout(TeamColor::Yellow),
+        Command::TimeoutBlue => RefereeCommand::Timeout(TeamColor::Blue),
+        Command::BallPlacementYellow => RefereeCommand::BallPlacement(TeamColor::Yellow),
+        Command::BallPlacementBlue => RefereeCommand::BallPlacement(TeamColor::Blue),
+        Command::IndirectFreeYellow
+        | Command::IndirectFreeBlue
+        | Command::GoalYellow
+        | Command::GoalBlue => RefereeCommand::Deprecated,
+    }
+}
+
+fn map_team_color(team: ProtocolTeam) -> TeamColor {
+    match team {
+        ProtocolTeam::Blue | ProtocolTeam::Unknown => TeamColor::Blue, // TODO: Handle unknown?
+        ProtocolTeam::Yellow => TeamColor::Yellow
+    }
+}
+
+fn map_team_color_i32(value: i32) -> TeamColor {
+    map_team_color(ProtocolTeam::from_i32(value).unwrap_or(ProtocolTeam::Unknown))
+}
+
+fn map_point(point: ProtocolPoint) -> Point2<f64> {
+    Point2::new(point.x.into(), point.y.into())
+}
+
+fn map_vector_point(vector: ProtocolVector2) -> Point2<f64> {
+    Point2::new(vector.x.into(), vector.y.into())
+}
+
+fn map_goal(goal: ProtocolGoal) -> Goal {
+    Goal {
+        by_team: map_team_color_i32(goal.by_team),
+        kicking_team: goal.kicking_team.map(map_team_color_i32),
+        kicking_bot: goal.kicking_bot,
+        location: goal.location.map(map_vector_point),
+        kick_location: goal.kick_location.map(map_vector_point),
+        max_ball_height: goal.max_ball_height.map(|h| h as f64),
+        num_bots_by_team: goal.num_robots_by_team,
+        last_touch_by_team: goal.last_touch_by_team,
+        message: goal.message,
+    }
+}
+
+fn map_type(event_type: ProtocolType) -> GameEventType{
+    match event_type {
+        ProtocolType::BallLeftFieldTouchLine=>GameEventType::BallLeftFieldTouchLine,
+        ProtocolType::BallLeftFieldGoalLine=>GameEventType::BallLeftFieldGoalLine,
+        ProtocolType::AimlessKick=>GameEventType::AimlessKick,
+        ProtocolType::AttackerTooCloseToDefenseArea=>GameEventType::AttackerTooCloseToDefenseArea,
+        ProtocolType::DefenderInDefenseArea=>GameEventType::DefenderInDefenseArea,
+        ProtocolType::BoundaryCrossing=>GameEventType::BoundaryCrossing,
+        ProtocolType::KeeperHeldBall=>GameEventType::KeeperHeldBall,
+        ProtocolType::BotDribbledBallTooFar=>GameEventType::BotDribbledBallTooFar,
+        ProtocolType::BotPushedBot=>GameEventType::BotPushedBot,
+        ProtocolType::BotHeldBallDeliberately=>GameEventType::BotHeldBallDeliberately,
+        ProtocolType::BotTippedOver=>GameEventType::BotTippedOver,
+        ProtocolType::AttackerTouchedBallInDefenseArea=>GameEventType::AttackerTouchedBallInDefenseArea,
+        ProtocolType::BotKickedBallTooFast=>GameEventType::BotKickedBallTooFast,
+        ProtocolType::BotCrashUnique=>GameEventType::BotCrashUnique,
+        ProtocolType::BotCrashDrawn=>GameEventType::BotCrashDrawn,
+        ProtocolType::DefenderTooCloseToKickPoint=>GameEventType::DefenderTooCloseToKickPoint,
+        ProtocolType::BotTooFastInStop=>GameEventType::BotTooFastInStop,
+        ProtocolType::BotInterferedPlacement=>GameEventType::BotInterferedPlacement,
+        ProtocolType::PossibleGoal=>GameEventType::PossibleGoal,
+        ProtocolType::Goal=>GameEventType::Goal,
+        ProtocolType::InvalidGoal=>GameEventType::InvalidGoal,
+        ProtocolType::AttackerDoubleTouchedBall=>GameEventType::AttackerDoubleTouchedBall,
+        ProtocolType::PlacementSucceeded=>GameEventType::PlacementSucceeded,
+        ProtocolType::PenaltyKickFailed=>GameEventType::PenaltyKickFailed,
+        ProtocolType::NoProgressInGame=>GameEventType::NoProgressInGame,
+        ProtocolType::PlacementFailed=>GameEventType::PlacementFailed,
+        ProtocolType::MultipleCards=>GameEventType::MultipleCards,
+        ProtocolType::MultipleFouls=>GameEventType::MultipleFouls,
+        ProtocolType::BotSubstitution=>GameEventType::BotSubstitution,
+        ProtocolType::TooManyRobots=>GameEventType::TooManyRobots,
+        ProtocolType::ChallengeFlag=>GameEventType::ChallengeFlag,
+        ProtocolType::ChallengeFlagHandled=>GameEventType::ChallengeFlagHandled,
+        ProtocolType::EmergencyStop=>GameEventType::EmergencyStop,
+        ProtocolType::UnsportingBehaviorMinor=>GameEventType::UnsportingBehaviorMinor,
+        ProtocolType::UnsportingBehaviorMajor=>GameEventType::UnsportingBehaviorMajor,
+        ProtocolType::UnknownGameEventType => todo!(),
+        ProtocolType::Prepared => todo!(),
+        ProtocolType::IndirectGoal => todo!(),
+        ProtocolType::ChippedGoal => todo!(),
+        ProtocolType::KickTimeout => todo!(),
+        ProtocolType::AttackerTouchedOpponentInDefenseArea => todo!(),
+        ProtocolType::AttackerTouchedOpponentInDefenseAreaSkipped => todo!(),
+        ProtocolType::BotCrashUniqueSkipped => todo!(),
+        ProtocolType::BotPushedBotSkipped => todo!(),
+        ProtocolType::DefenderInDefenseAreaPartially => todo!(),
+        ProtocolType::MultiplePlacementFailures => todo!(),
+    }
+}
+
+fn map_ball_left_field(value: protocol_event::BallLeftField) -> BallLeftField {
+    BallLeftField {
+        by_team: map_team_color_i32(value.by_team),
+        by_bot: value.by_bot,
+        location: value.location.map(map_vector_point),
+    }
+}
+
+fn map_game_event(game_event: ProtocolEvent) -> Option<GameEvent> {
+    let created_timestamp = game_event.created_timestamp;
+    let event = game_event.event.map(map_event).flatten();
+    /*
+    for ele in game_event.origin {
+        println!("{}",ele);
+    }
+    */
+    if let Some(event) = event {
+        Some(GameEvent{
+            type_event: match game_event.r#type{
+                Some(r#type) => ProtocolType::from_i32(r#type)
+                    .map(map_type),
+                None => None
+            },
+            created_timestamp,
+            event,
+            origin: Vec::from([EventOrigin::Autorefs(game_event.origin)])
+        })
+    }else{
+        None
+    }
+}
+
+fn map_event(event: ProtocolEventData) -> Option<Event> {
+    match event {
+        ProtocolEventData::BallLeftFieldTouchLine(data) => {
+            Some(Event::BallLeftFieldTouchLine(map_ball_left_field(data)))
+        }
+        ProtocolEventData::BallLeftFieldGoalLine(data) => {
+            Some(Event::BallLeftFieldTouchLine(map_ball_left_field(data)))
+        }
+        ProtocolEventData::AimlessKick(data) => {
+            Some(Event::AimlessKick(AimlessKick {
+                by_team: map_team_color_i32(data.by_team),
+                by_bot: data.by_bot,
+                location: data.location.map(map_vector_point),
+                kick_location: data.kick_location.map(map_vector_point),
+            }))
+        }
+        ProtocolEventData::AttackerTooCloseToDefenseArea(data) => {
+            Some(Event::AttackerTooCloseToDefenseArea(AttackerTooCloseToDefenseArea {
+                by_team: map_team_color_i32(data.by_team),
+                by_bot: data.by_bot,
+                location: data.location.map(map_vector_point),
+                distance: data.distance.map(|d| d as f64),
+                ball_location: data.ball_location.map(map_vector_point),
+            }))
+        }
+        ProtocolEventData::DefenderInDefenseArea(data) => {
+            Some(Event::DefenderInDefenseArea(DefenderInDefenseArea {
+                by_team: map_team_color_i32(data.by_team),
+                by_bot: data.by_bot,
+                location: data.location.map(map_vector_point),
+                distance: data.distance.map(|d| d as f64),
+            }))
+        }
+        ProtocolEventData::BoundaryCrossing(data) => {
+            Some(Event::BoundaryCrossing(BoundaryCrossing {
+                by_team: map_team_color_i32(data.by_team),
+                location: data.location.map(map_vector_point),
+            }))
+        }
+        ProtocolEventData::KeeperHeldBall(data) => {
+            Some(Event::KeeperHeldBall(KeeperHeldBall {
+                by_team: map_team_color_i32(data.by_team),
+                location: data.location.map(map_vector_point),
+                duration: data.duration.map(|d| Duration::seconds(d as i64)), // TODO: More precision?
+            }))
+        }
+        ProtocolEventData::BotDribbledBallTooFar(data) => {
+            Some(Event::BotDribbledBallTooFar(BotDribbledBallTooFar {
+                by_team: map_team_color_i32(data.by_team),
+                by_bot: data.by_bot,
+                start: data.start.map(map_vector_point),
+                end: data.end.map(map_vector_point),
+            }))
+        }
+        ProtocolEventData::BotPushedBot(data) => {
+            Some(Event::BotPushedBot(BotPushedBot {
+                by_team: map_team_color_i32(data.by_team),
+                violator: data.violator,
+                victim: data.victim,
+                location: data.location.map(map_vector_point),
+                pushed_distance: data.pushed_distance.map(|d| d as f64),
+            }))
+        }
+        ProtocolEventData::BotHeldBallDeliberately(data) => {
+            Some(Event::BotHeldBallDeliberately(BotHeldBallDeliberately {
+                by_team: map_team_color_i32(data.by_team),
+                by_bot: data.by_bot,
+                location: data.location.map(map_vector_point),
+                duration: data.duration.map(|d| Duration::seconds(d as i64)), // TODO: More precision?
+            }))
+        }
+        ProtocolEventData::BotTippedOver(data) => {
+            Some(Event::BotTippedOver(BotTippedOver {
+                by_team: map_team_color_i32(data.by_team),
+                by_bot: data.by_bot,
+                location: data.location.map(map_vector_point),
+                ball_location: data.ball_location.map(map_vector_point),
+            }))
+        }
+        ProtocolEventData::AttackerTouchedBallInDefenseArea(data) => {
+            Some(Event::AttackerTouchedBallInDefenseArea(AttackerTouchedBallInDefenseArea {
+                by_team: map_team_color_i32(data.by_team),
+                by_bot: data.by_bot,
+                location: data.location.map(map_vector_point),
+                distance: data.distance.map(|d| d as f64),
+            }))
+        }
+        ProtocolEventData::BotKickedBallTooFast(data) => {
+            Some(Event::BotKickedBallTooFast(BotKickedBallTooFast {
+                by_team: map_team_color_i32(data.by_team),
+                by_bot: data.by_bot,
+                location: data.location.map(map_vector_point),
+                initial_ball_speed: data.initial_ball_speed.map(|s| s as f64),
+                chipped: data.chipped,
+            }))
+        }
+        ProtocolEventData::BotCrashUnique(data) => {
+            Some(Event::BotCrashUnique(BotCrashUnique {
+                by_team: map_team_color_i32(data.by_team),
+                violator: data.violator,
+                victim: data.victim,
+                location: data.location.map(map_vector_point),
+                crash_speed: data.crash_speed.map(|s| s as f64),
+                speed_diff: data.speed_diff.map(|d| d as f64),
+                crash_angle: data.crash_angle.map(|a| a as f64),
+            }))
+        }
+        ProtocolEventData::BotCrashDrawn(data) => {
+            Some(Event::BotCrashDrawn(BotCrashDrawn {
+                bot_blue: data.bot_blue,
+                bot_yellow: data.bot_yellow,
+                crash_speed: data.crash_speed.map(|s| s as f64),
+                speed_diff: data.speed_diff.map(|d| d as f64),
+                crash_angle: data.crash_angle.map(|a| a as f64),
+                location: None,
+            }))
+        }
+        ProtocolEventData::BotTooFastInStop(data) => {
+            Some(Event::BotTooFastInStop(BotTooFastInStop {
+                by_team: map_team_color_i32(data.by_team),
+                by_bot: data.by_bot,
+                location: data.location.map(map_vector_point),
+                speed: data.speed.map(|s| s as f64),
+            }))
+        }
+        ProtocolEventData::BotInterferedPlacement(data) => {
+            Some(Event::BotInterferedPlacement(BotInterferedPlacement {
+                by_team: map_team_color_i32(data.by_team),
+                by_bot: data.by_bot,
+                location: data.location.map(map_vector_point),
+            }))
+        }
+        ProtocolEventData::PossibleGoal(data) => {
+            Some(Event::PossibleGoal(map_goal(data)))
+        }
+        ProtocolEventData::Goal(data) => {
+            Some(Event::Goal(map_goal(data)))
+        }
+        ProtocolEventData::InvalidGoal(data) => {
+            Some(Event::InvalidGoal(map_goal(data)))
+        }
+        ProtocolEventData::AttackerDoubleTouchedBall(data) => {
+            Some(Event::AttackerDoubleTouchedBall(AttackerDoubleTouchedBall {
+                by_team: map_team_color_i32(data.by_team),
+                by_bot: data.by_bot,
+                location: data.location.map(map_vector_point),
+            }))
+        }
+        ProtocolEventData::PlacementSucceeded(data) => {
+            Some(Event::PlacementSucceeded(PlacementSucceeded {
+                by_team: map_team_color_i32(data.by_team),
+                time_taken: data.time_taken.map(|d| d as f64),
+                precision: data.precision.map(|p| p as f64),
+                distance: data.distance.map(|d| d as f64),
+            }))
+        }
+        ProtocolEventData::PlacementFailed(data) => {
+            Some(Event::PlacementFailed(PlacementFailed {
+                by_team: map_team_color_i32(data.by_team),
+                remaining_distance: data.remaining_distance.map(|d| d as f64),
+            }))
+        }
+        ProtocolEventData::PenaltyKickFailed(data) => {
+            Some(Event::PenaltyKickFailed(PenaltyKickFailed {
+                by_team: map_team_color_i32(data.by_team),
+                location: data.location.map(map_vector_point),
+                reason: None,
+            }))
+        }
+        ProtocolEventData::NoProgressInGame(data) => {
+            Some(Event::NoProgressInGame(NoProgressInGame {
+                location: data.location.map(map_vector_point),
+                time: data.time.map(|d| Duration::seconds(d as i64)),
+            }))
+        }
+        ProtocolEventData::MultipleCards(data) => {
+            Some(Event::MultipleCards(map_team_color_i32(data.by_team)))
+        }
+        ProtocolEventData::MultipleFouls(data) => {
+            Some(Event::MultipleFouls(MultipleFouls {
+                by_team: map_team_color_i32(data.by_team),
+                caused_game_events: vec![], // TODO
+            }))
+        }
+        ProtocolEventData::BotSubstitution(data) => {
+            Some(Event::BotSubstitution(map_team_color_i32(data.by_team)))
+        }
+        ProtocolEventData::TooManyRobots(data) => {
+            Some(Event::TooManyRobots(TooManyRobots {
+                by_team: map_team_color_i32(data.by_team),
+                num_robots_allowed: data.num_robots_allowed.map(|n| if n < 0 { 0 } else { n as u32 }),
+                num_robots_on_field: data.num_robots_on_field.map(|n| if n < 0 { 0 } else { n as u32 }),
+                ball_location: data.ball_location.map(map_vector_point),
+            }))
+        }
+        ProtocolEventData::ChallengeFlag(data) => {
+            Some(Event::ChallengeFlag(map_team_color_i32(data.by_team)))
+        }
+        ProtocolEventData::EmergencyStop(data) => {
+            Some(Event::EmergencyStop(map_team_color_i32(data.by_team)))
+        }
+        ProtocolEventData::UnsportingBehaviorMinor(data) => {
+            Some(Event::UnsportingBehaviorMinor(UnsportingBehaviorMinor {
+                by_team: map_team_color_i32(data.by_team),
+                reason: data.reason,
+            }))
+        }
+        ProtocolEventData::UnsportingBehaviorMajor(data) => {
+            Some(Event::UnsportingBehaviorMajor(UnsportingBehaviorMajor {
+                by_team: map_team_color_i32(data.by_team),
+                reason: data.reason,
+            }))
+        }
+        ProtocolEventData::DefenderTooCloseToKickPoint(data) => {
+            Some(Event::DefenderTooCloseToKickPoint(DefenderTooCloseToKickPoint {
+                by_team: map_team_color_i32(data.by_team),
+                by_bot: data.by_bot,
+                location: data.location.map(map_vector_point),
+                distance: data.distance.map(|d| d as f64),
+            }))
+        }
+
+        // DEPRECATED
+        ProtocolEventData::Prepared(_) |
+        ProtocolEventData::IndirectGoal(_) |
+        ProtocolEventData::ChippedGoal(_) |
+        ProtocolEventData::KickTimeout(_) |
+        ProtocolEventData::AttackerTouchedOpponentInDefenseArea(_) |
+        ProtocolEventData::AttackerTouchedOpponentInDefenseAreaSkipped(_) |
+        ProtocolEventData::BotCrashUniqueSkipped(_) |
+        ProtocolEventData::BotPushedBotSkipped(_) |
+        ProtocolEventData::DefenderInDefenseAreaPartially(_) |
+        ProtocolEventData::ChallengeFlagHandled(_) |
+        ProtocolEventData::MultiplePlacementFailures(_) => {
+            None
+        }
+    }
+}
+
+struct RefereeDeserializationError;
+
+fn map_protobuf_referee(
+    mut packet: ProtocolReferee,
+    team_color: &TeamColor,
+) -> Result<Referee, RefereeDeserializationError> {
+    let (ally, enemy) = match team_color {
+        TeamColor::Yellow => (packet.yellow, packet.blue),
+        TeamColor::Blue => (packet.blue, packet.yellow),
+    };
+    Ok(Referee {
+        source_identifier: packet.source_identifier,
+        match_type: packet.match_type.map(|match_type|ProtocolMatchType::from_i32(match_type).map(map_match_type)).flatten(), // TODO: Handle error
+        packet_timestamp: create_date_time((packet.packet_timestamp / 1_000_000) as i64),
+        stage: ProtocolStage::from_i32(packet.stage)
+            .map(map_stage)
+            .ok_or(RefereeDeserializationError)?,
+        stage_time_left: packet
+            .stage_time_left
+            .map(|d| Duration::microseconds(d as i64)),
+        command: ProtocolCommand::from_i32(packet.command)
+            .map(map_command)
+            .ok_or(RefereeDeserializationError)?,
+        command_counter: packet.command_counter,
+        command_timestamp: create_date_time((packet.command_timestamp / 1_000_000) as i64),
+        ally: to_team_infos(ally),   // TODO : Rename and check
+        enemy: to_team_infos(enemy), // TODO : Rename and check
+        designated_position: packet.designated_position.map(map_point),
+        positive_half: packet.blue_team_on_positive_half.map(|b| {
+            if b {
+                TeamColor::Blue
+            } else {
+                TeamColor::Yellow
+            }
+        }),
+        next_command: packet
+            .next_command
+            .map(|c| ProtocolCommand::from_i32(c))
+            .flatten()
+            .map(map_command),
+        game_events: packet.game_events.drain(..).filter_map(map_game_event).collect(),
+        game_event_proposals: packet.game_event_proposals.drain(..).map(|mut p| GameEventProposalGroup {
+            game_event: p.game_event.drain(..).filter_map(map_game_event).collect(),
+            accepted: p.accepted,
+        }).collect(),
+        current_action_time_remaining: packet
+            .current_action_time_remaining
+            .map(|d| Duration::microseconds(d as i64)),
+    })
+
+    // Ok(Referee {})
+}
+
+impl PreFilter for ProtocolPacketTranslateFilter {
+    fn step(
+        &mut self,
+        inbound_data: &mut InboundData,
+        team_color: &TeamColor,
+        filter_data: &mut FilterData,
+    ) {
+        filter_data.referee.extend(
+            inbound_data
+                .gc_packet
+                .drain(..)
+                .filter_map(|packet| map_protobuf_referee(packet, team_color).ok()),
+        );
+    }
+}

--- a/crates/crabe_filter/src/pre_filter/vision.rs
+++ b/crates/crabe_filter/src/pre_filter/vision.rs
@@ -241,7 +241,7 @@ impl VisionFilter {
 impl PreFilter for VisionFilter {
     fn step(
         &mut self,
-        inbound_data: &InboundData,
+        inbound_data: &mut InboundData,
         team_color: &TeamColor,
         filter_data: &mut FilterData,
     ) {

--- a/crates/crabe_framework/src/config.rs
+++ b/crates/crabe_framework/src/config.rs
@@ -9,4 +9,7 @@ pub struct CommonConfig {
     /// Whether robots are operating in the real world or in simulation.
     #[arg(short, long)]
     pub real: bool,
+    /// Indicates whether to activate the game controller for the RoboCup SSL.
+    #[arg(short, long)]
+    pub gc: bool,
 }

--- a/crates/crabe_framework/src/data/world.rs
+++ b/crates/crabe_framework/src/data/world.rs
@@ -12,6 +12,8 @@ mod team;
 pub use self::team::{Team, TeamColor};
 
 mod game_data;
+pub mod game_state;
+
 pub use self::game_data::GameData;
 
 use crate::config::CommonConfig;

--- a/crates/crabe_framework/src/data/world/game_data.rs
+++ b/crates/crabe_framework/src/data/world/game_data.rs
@@ -1,5 +1,7 @@
 use crate::data::world::{Team, TeamColor};
 use serde::Serialize;
+use crate::data::world::game_state::GameState;
+use crate::data::world::game_state::HaltedState::Halt;
 
 /// The `GameData` struct represents the state of the SSL game, including the teams and which team is on the positive half of the field.
 #[derive(Serialize, Clone, Debug)]
@@ -11,6 +13,8 @@ pub struct GameData {
     pub enemy: Team,
     /// The color of the team that is on the positive half of the field.
     pub positive_half: TeamColor,
+    /// The state of the game
+    pub state: GameState,
 }
 
 impl GameData {
@@ -20,6 +24,7 @@ impl GameData {
             ally: Team::with_color(team_color),
             enemy: Team::with_color(team_color.opposite()),
             positive_half: team_color.opposite(),
+            state: GameState::Halted(Halt),
         }
     }
 }

--- a/crates/crabe_framework/src/data/world/game_state.rs
+++ b/crates/crabe_framework/src/data/world/game_state.rs
@@ -1,0 +1,35 @@
+use crate::data::world::TeamColor;
+use serde::Serialize;
+
+#[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum GameState {
+    Halted(HaltedState),
+    Stopped(StoppedState),
+    Running(RunningState),
+}
+
+#[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum HaltedState {
+    Halt,
+    Timeout,
+}
+
+#[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum StoppedState {
+    Stop,
+    PrepareKickoff(TeamColor),
+    PreparePenalty(TeamColor),
+    BallPlacement(TeamColor),
+}
+
+#[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum RunningState {
+    KickOff(TeamColor),
+    Penalty(TeamColor),
+    FreeKick(TeamColor),
+    Run,
+}

--- a/crates/crabe_framework/src/data/world/team.rs
+++ b/crates/crabe_framework/src/data/world/team.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// The `TeamColor` enum represents the color of a team in the SSL game, either blue or yellow.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Eq, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum TeamColor {
     Blue,

--- a/crates/crabe_io/src/pipeline/input.rs
+++ b/crates/crabe_io/src/pipeline/input.rs
@@ -8,9 +8,6 @@ use crabe_framework::data::output::FeedbackMap;
 
 #[derive(Args)]
 pub struct InputConfig {
-    #[arg(long)]
-    gc: bool,
-
     #[command(flatten)]
     #[command(next_help_heading = "Vision")]
     pub vision_cfg: VisionConfig,
@@ -36,7 +33,7 @@ impl InputPipeline {
             common_cfg,
         ))];
 
-        if input_cfg.gc {
+        if common_cfg.gc {
             tasks.push(Box::new(GameController::with_config(input_cfg.gc_cfg)));
         }
 


### PR DESCRIPTION
This PR includes the changes made in the robocup relate to the game controller.

## Task list

- [x] Move gc options to common config
- [x] Create a gc pre filters, i.e. only the translation of the Protocol packet structure into our own structs which can then be used inside the software (the Protocol packets aren't modifiable)
- [x] Create a gc post filters, that only updates the information about which team is on `positive_half`. The goal isn't to re-introduce the whole state machine, but only to use the data about the team on positive half to implement #89 