### PR TITLE
Vision asserted MoveTo test

### DIFF
--- a/crates/crabe_decision/src/manager/manual.rs
+++ b/crates/crabe_decision/src/manager/manual.rs
@@ -1,6 +1,6 @@
 use crate::action::ActionWrapper;
 use crate::manager::Manager;
-use crate::strategy::testing::Square;
+use crate::strategy::testing::{Square, TestVisionMoveTo};
 use crate::strategy::Strategy;
 use crabe_framework::data::tool::ToolData;
 use crabe_framework::data::world::World;
@@ -20,7 +20,7 @@ impl Manual {
     /// Creates a new `Manual` instance with the desired strategies to test.
     pub fn new() -> Self {
         Self {
-            strategies: vec![Box::new(Square::new(0))],
+            strategies: vec![Box::new(TestVisionMoveTo::new(vec![0], true))],
         }
     }
 }

--- a/crates/crabe_decision/src/strategy/testing.rs
+++ b/crates/crabe_decision/src/strategy/testing.rs
@@ -3,3 +3,6 @@
 /// for use in a game.
 mod square;
 pub use self::square::Square;
+
+mod test_vision_moveto;
+pub use self::test_vision_moveto::TestVisionMoveTo;

--- a/crates/crabe_decision/src/strategy/testing/test_vision_moveto.rs
+++ b/crates/crabe_decision/src/strategy/testing/test_vision_moveto.rs
@@ -1,3 +1,4 @@
+use std::f64::consts::{FRAC_PI_6, FRAC_PI_8};
 use std::ops::Div;
 use nalgebra::{distance, Point2};
 use crabe_framework::data::output::Command;
@@ -43,7 +44,7 @@ impl Strategy for TestVisionMoveTo {
         // WARNING : Not clearing the action_wrapper leads to stuttering
         action_wrapper.clear_all();
         let sign = if self.positive_half { 1. } else { -1. };
-        let mut y_target = 0.;
+        let mut y_target;
         let mut next_status = TestVisionMoveToStatus::Placement;
         match self.status {
             TestVisionMoveToStatus::Placement => {
@@ -77,7 +78,7 @@ impl Strategy for TestVisionMoveTo {
             .filter(|(ally_id, _)| self.ids.contains(ally_id))
             .for_each(|(ally_id, ally_info)| {
                 let target = Point2::new((*ally_id as f64).div(2.) * sign, y_target);
-                action_wrapper.push(*ally_id, MoveTo::new(target, 0.));
+                action_wrapper.push(*ally_id, MoveTo::new(target, FRAC_PI_6 * (*ally_id as f64)));
                 change_status = change_status && distance(&target, &ally_info.pose.position) <= DIST_TARGET_REACHED
             });
         if change_status {

--- a/crates/crabe_decision/src/strategy/testing/test_vision_moveto.rs
+++ b/crates/crabe_decision/src/strategy/testing/test_vision_moveto.rs
@@ -38,7 +38,7 @@ impl TestVisionMoveTo {
 impl Strategy for TestVisionMoveTo {
     fn step(&mut self, world: &World, _: &mut ToolData, action_wrapper: &mut ActionWrapper) -> bool {
         // WARNING : Not clearing the action_wrapper leads to stuttering
-        action_wrapper.clear();
+        action_wrapper.clear_all();
         let sign = if self.positive_half { 1. } else { -1. };
         let mut y_target = 0.;
         let mut next_status = TestVisionMoveToStatus::MovingForward;

--- a/crates/crabe_decision/src/strategy/testing/test_vision_moveto.rs
+++ b/crates/crabe_decision/src/strategy/testing/test_vision_moveto.rs
@@ -35,6 +35,10 @@ impl TestVisionMoveTo {
 }
 
 impl Strategy for TestVisionMoveTo {
+    fn name(&self) -> &'static str {
+        "TestVisionMoveTo"
+    }
+
     fn step(&mut self, world: &World, _: &mut ToolData, action_wrapper: &mut ActionWrapper) -> bool {
         // WARNING : Not clearing the action_wrapper leads to stuttering
         action_wrapper.clear_all();
@@ -71,9 +75,5 @@ impl Strategy for TestVisionMoveTo {
         }
 
         false
-    }
-
-    fn name(&self) -> &'static str {
-        "TestVisionMoveTo"
     }
 }

--- a/crates/crabe_decision/src/strategy/testing/test_vision_moveto.rs
+++ b/crates/crabe_decision/src/strategy/testing/test_vision_moveto.rs
@@ -31,63 +31,49 @@ impl TestVisionMoveTo {
             positive_half,
         }
     }
+
+
 }
 
 impl Strategy for TestVisionMoveTo {
     fn step(&mut self, world: &World, _: &mut ToolData, action_wrapper: &mut ActionWrapper) -> bool {
-        // WARNING : Not clearing the action_wrapper
+        // WARNING : Not clearing the action_wrapper leads to stuttering
         action_wrapper.clear();
         let sign = if self.positive_half { 1. } else { -1. };
-        let mut finished = world.allies_bot.len() > 0;
+        let mut y_target = 0.;
+        let mut next_status = TestVisionMoveToStatus::MovingForward;
         match self.status {
             TestVisionMoveToStatus::Placement => {
-                world.allies_bot.iter()
-                    .filter(|(ally_id, _)| self.ids.contains(ally_id))
-                    .for_each(|(ally_id, ally_info)| {
-                        let target = Point2::new((*ally_id as f64).div(2.) * sign, 0.);
-                        action_wrapper.push(*ally_id, MoveTo::new(
-                            target,
-                            0., 0., None, false, false),
-                        );
-                        finished = finished && distance(&ally_info.pose.position, &target) <= DIST_TARGET_REACHED;
-                    });
-
-                if finished {
-                    self.status = TestVisionMoveToStatus::MovingForward;
-                }
+                y_target = 0.;
+                next_status = TestVisionMoveToStatus::MovingForward;
             }
-
             TestVisionMoveToStatus::MovingForward => {
-                let mut change_status = true;
-                world.allies_bot.iter()
-                    .filter(|(ally_id, _)| self.ids.contains(ally_id))
-                    .for_each(|(ally_id, ally_info)| {
-                        let target_forward = Point2::new((*ally_id as f64).div(2.) * sign, 1.);
-                        action_wrapper.push(*ally_id, MoveTo::new(
-                            target_forward,
-                            0., 0., None, false, false),
-                        );
-                        change_status = distance(&target_forward, &ally_info.pose.position) <= DIST_TARGET_REACHED
-                });
-                self.status = if change_status { TestVisionMoveToStatus::MovingBackwards } else { TestVisionMoveToStatus::MovingForward };
+                y_target = 1.;
+                next_status = TestVisionMoveToStatus::MovingBackwards;
             }
-
             TestVisionMoveToStatus::MovingBackwards => {
-                let mut change_status = true;
-                world.allies_bot.iter()
-                    .filter(|(ally_id, _)| self.ids.contains(ally_id))
-                    .for_each(|(ally_id, ally_info)| {
-                    let target_backwards = Point2::new((*ally_id as f64).div(2.) * sign, -1.);
-                    action_wrapper.push(*ally_id, MoveTo::new(
-                        target_backwards,
-                        0., 0., None, false, false),
-                    );
-                    change_status = distance(&target_backwards, &ally_info.pose.position) <= DIST_TARGET_REACHED
-                });
-                self.status = if change_status { TestVisionMoveToStatus::MovingForward } else { TestVisionMoveToStatus::MovingBackwards };
+                y_target = -1.;
+                next_status = TestVisionMoveToStatus::MovingForward;
             }
         }
-        dbg!(&self.status);
+
+        // Move robots
+        let mut change_status = false;
+
+        world.allies_bot.iter()
+            .filter(|(ally_id, _)| self.ids.contains(ally_id))
+            .for_each(|(ally_id, ally_info)| {
+                let target = Point2::new((*ally_id as f64).div(2.) * sign, y_target);
+                action_wrapper.push(*ally_id, MoveTo::new(
+                    target,
+                    0., 0., None, false, false),
+                );
+                change_status = distance(&target, &ally_info.pose.position) <= DIST_TARGET_REACHED
+            });
+        if change_status {
+            self.status = next_status;
+        }
+
         false
     }
 

--- a/crates/crabe_decision/src/strategy/testing/test_vision_moveto.rs
+++ b/crates/crabe_decision/src/strategy/testing/test_vision_moveto.rs
@@ -1,0 +1,96 @@
+use nalgebra::{distance, Point2};
+use crabe_framework::data::output::Command;
+use crabe_framework::data::tool::ToolData;
+use crabe_framework::data::world::{AllyInfo, RobotMap, World};
+use crate::action::{Actions, ActionWrapper};
+use crate::action::move_to::MoveTo;
+use crate::action::order_raw::RawOrder;
+use crate::strategy::Strategy;
+
+const DIST_TARGET_REACHED: f64 = 0.25;
+
+#[derive(Debug)]
+enum TestVisionMoveToStatus {
+    Placement,
+    MovingForward,
+    MovingBackwards,
+}
+
+pub struct TestVisionMoveTo {
+    ids: Vec<u8>,
+    status: TestVisionMoveToStatus,
+    positive_half: bool,
+}
+
+impl TestVisionMoveTo {
+    pub fn new(ids: Vec<u8>, positive_half: bool) -> Self {
+        Self {
+            ids,
+            status: TestVisionMoveToStatus::Placement,
+            positive_half,
+        }
+    }
+}
+
+impl Strategy for TestVisionMoveTo {
+    fn step(&mut self, world: &World, _: &mut ToolData, action_wrapper: &mut ActionWrapper) -> bool {
+        // WARNING : Not clearing the action_wrapper
+        // action_wrapper.clear();
+        let sign = if self.positive_half { 1. } else { -1. };
+        let mut finished = world.allies_bot.len() > 0;
+        match self.status {
+            TestVisionMoveToStatus::Placement => {
+                world.allies_bot.iter()
+                    .filter(|(ally_id, _)| self.ids.contains(ally_id))
+                    .for_each(|(ally_id, ally_info)| {
+                        let target = Point2::new(*ally_id as f64 * sign, 0.);
+                        action_wrapper.push(*ally_id, MoveTo::new(
+                            target,
+                            0., 0., None, false, false),
+                        );
+                        finished = finished && distance(&ally_info.pose.position, &target) <= DIST_TARGET_REACHED;
+                    });
+
+                if finished {
+                    self.status = TestVisionMoveToStatus::MovingForward;
+                }
+            }
+
+            TestVisionMoveToStatus::MovingForward => {
+                let mut change_status = true;
+                world.allies_bot.iter()
+                    .filter(|(ally_id, _)| self.ids.contains(ally_id))
+                    .for_each(|(ally_id, ally_info)| {
+                        let target_forward = Point2::new(*ally_id as f64 * sign, 1.);
+                        action_wrapper.push(*ally_id, MoveTo::new(
+                            target_forward,
+                            0., 0., None, false, false),
+                        );
+                        change_status = distance(&target_forward, &ally_info.pose.position) <= DIST_TARGET_REACHED
+                });
+                self.status = if change_status { TestVisionMoveToStatus::MovingBackwards } else { TestVisionMoveToStatus::MovingForward };
+            }
+
+            TestVisionMoveToStatus::MovingBackwards => {
+                let mut change_status = true;
+                world.allies_bot.iter()
+                    .filter(|(ally_id, _)| self.ids.contains(ally_id))
+                    .for_each(|(ally_id, ally_info)| {
+                    let target_backwards = Point2::new(*ally_id as f64 * sign, -1.);
+                    action_wrapper.push(*ally_id, MoveTo::new(
+                        target_backwards,
+                        0., 0., None, false, false),
+                    );
+                    change_status = distance(&target_backwards, &ally_info.pose.position) <= DIST_TARGET_REACHED
+                });
+                self.status = if change_status { TestVisionMoveToStatus::MovingForward } else { TestVisionMoveToStatus::MovingBackwards };
+            }
+        }
+        dbg!(&self.status);
+        false
+    }
+
+    fn name(&self) -> &'static str {
+        "TestVisionMoveTo"
+    }
+}

--- a/crates/crabe_decision/src/strategy/testing/test_vision_moveto.rs
+++ b/crates/crabe_decision/src/strategy/testing/test_vision_moveto.rs
@@ -1,3 +1,4 @@
+use std::ops::Div;
 use nalgebra::{distance, Point2};
 use crabe_framework::data::output::Command;
 use crabe_framework::data::tool::ToolData;
@@ -35,7 +36,7 @@ impl TestVisionMoveTo {
 impl Strategy for TestVisionMoveTo {
     fn step(&mut self, world: &World, _: &mut ToolData, action_wrapper: &mut ActionWrapper) -> bool {
         // WARNING : Not clearing the action_wrapper
-        // action_wrapper.clear();
+        action_wrapper.clear();
         let sign = if self.positive_half { 1. } else { -1. };
         let mut finished = world.allies_bot.len() > 0;
         match self.status {
@@ -43,7 +44,7 @@ impl Strategy for TestVisionMoveTo {
                 world.allies_bot.iter()
                     .filter(|(ally_id, _)| self.ids.contains(ally_id))
                     .for_each(|(ally_id, ally_info)| {
-                        let target = Point2::new(*ally_id as f64 * sign, 0.);
+                        let target = Point2::new((*ally_id as f64).div(2.) * sign, 0.);
                         action_wrapper.push(*ally_id, MoveTo::new(
                             target,
                             0., 0., None, false, false),
@@ -61,7 +62,7 @@ impl Strategy for TestVisionMoveTo {
                 world.allies_bot.iter()
                     .filter(|(ally_id, _)| self.ids.contains(ally_id))
                     .for_each(|(ally_id, ally_info)| {
-                        let target_forward = Point2::new(*ally_id as f64 * sign, 1.);
+                        let target_forward = Point2::new((*ally_id as f64).div(2.) * sign, 1.);
                         action_wrapper.push(*ally_id, MoveTo::new(
                             target_forward,
                             0., 0., None, false, false),
@@ -76,7 +77,7 @@ impl Strategy for TestVisionMoveTo {
                 world.allies_bot.iter()
                     .filter(|(ally_id, _)| self.ids.contains(ally_id))
                     .for_each(|(ally_id, ally_info)| {
-                    let target_backwards = Point2::new(*ally_id as f64 * sign, -1.);
+                    let target_backwards = Point2::new((*ally_id as f64).div(2.) * sign, -1.);
                     action_wrapper.push(*ally_id, MoveTo::new(
                         target_backwards,
                         0., 0., None, false, false),

--- a/crates/crabe_decision/src/strategy/testing/test_vision_moveto.rs
+++ b/crates/crabe_decision/src/strategy/testing/test_vision_moveto.rs
@@ -44,11 +44,21 @@ impl Strategy for TestVisionMoveTo {
         action_wrapper.clear_all();
         let sign = if self.positive_half { 1. } else { -1. };
         let mut y_target = 0.;
-        let mut next_status = TestVisionMoveToStatus::MovingForward;
+        let mut next_status = TestVisionMoveToStatus::Placement;
         match self.status {
             TestVisionMoveToStatus::Placement => {
                 y_target = 0.;
-                next_status = TestVisionMoveToStatus::MovingForward;
+                let allies_placed =
+                    world.allies_bot
+                        .iter()
+                        .filter(|(id, rob)|
+                            self.ids.contains(id) && rob.pose.position.y <= DIST_TARGET_REACHED
+                        ).count();
+
+                if allies_placed == self.ids.len() {
+                    next_status = TestVisionMoveToStatus::MovingForward
+                }
+
             }
             TestVisionMoveToStatus::MovingForward => {
                 y_target = 1.;

--- a/crates/crabe_decision/src/strategy/testing/test_vision_moveto.rs
+++ b/crates/crabe_decision/src/strategy/testing/test_vision_moveto.rs
@@ -2,13 +2,12 @@ use std::ops::Div;
 use nalgebra::{distance, Point2};
 use crabe_framework::data::output::Command;
 use crabe_framework::data::tool::ToolData;
-use crabe_framework::data::world::{AllyInfo, RobotMap, World};
-use crate::action::{Actions, ActionWrapper};
+use crabe_framework::data::world::World;
+use crate::action::ActionWrapper;
 use crate::action::move_to::MoveTo;
-use crate::action::order_raw::RawOrder;
 use crate::strategy::Strategy;
 
-const DIST_TARGET_REACHED: f64 = 0.25;
+const DIST_TARGET_REACHED: f64 = 0.1;
 
 #[derive(Debug)]
 enum TestVisionMoveToStatus {
@@ -58,17 +57,14 @@ impl Strategy for TestVisionMoveTo {
         }
 
         // Move robots
-        let mut change_status = false;
+        let mut change_status = true;
 
         world.allies_bot.iter()
             .filter(|(ally_id, _)| self.ids.contains(ally_id))
             .for_each(|(ally_id, ally_info)| {
                 let target = Point2::new((*ally_id as f64).div(2.) * sign, y_target);
-                action_wrapper.push(*ally_id, MoveTo::new(
-                    target,
-                    0., 0., None, false, false),
-                );
-                change_status = distance(&target, &ally_info.pose.position) <= DIST_TARGET_REACHED
+                action_wrapper.push(*ally_id, MoveTo::new(target, 0.));
+                change_status = change_status && distance(&target, &ally_info.pose.position) <= DIST_TARGET_REACHED
             });
         if change_status {
             self.status = next_status;


### PR DESCRIPTION
Taken from #69 

Moves the selected robots on the horizontal middle line of the field, then moves them together from left to right in a straight line. Every robot is spaced based on its id (y location is `robot_id.div(2)`) and the test will wait for all robots to arrive properly to the designated location. That is, when they all properly placed to the left side, then they will go to the right side, and cetera.

Useful test to identify whether robot movement is affected by mechanical problems, communication problems or something else.