### PR TITLE
[ft-rbc23] More gk area points, shape refactor in structs

### DIFF
--- a/crates/crabe_filter/src/post_filter/geometry.rs
+++ b/crates/crabe_filter/src/post_filter/geometry.rs
@@ -5,7 +5,7 @@ use crabe_framework::data::geometry::Goal;
 use crabe_framework::data::geometry::Penalty;
 use crabe_framework::data::geometry::{Field, Geometry};
 use crabe_framework::data::world::World;
-use crabe_math::shape::Circle;
+use crabe_math::shape::{Circle, Line};
 use nalgebra::Point2;
 
 pub struct GeometryFilter;
@@ -55,13 +55,37 @@ fn geometry_to_penalty(cam_geometry: &CamGeometry, positive: bool) -> Penalty {
 
 fn geometry_to_goal(cam_geometry: &CamGeometry, positive: bool) -> Goal {
     let factor = if positive { 1.0 } else { -1.0 };
+    let half_geo_cam_width = cam_geometry.goal_width / 2.0;
+    let bottom_right = Point2::new(
+        factor * ((cam_geometry.field_length / 2.0)),
+        factor * -half_geo_cam_width,
+    );
+    let bottom_left = Point2::new(
+        factor * ((cam_geometry.field_length / 2.0)),
+        factor * half_geo_cam_width,
+    );
     Goal {
         width: cam_geometry.goal_width,
         depth: cam_geometry.goal_depth,
         top_left_position: Point2::new(
             factor * ((cam_geometry.field_length / 2.0) + cam_geometry.goal_depth),
-            factor * (cam_geometry.goal_width / 2.0),
+            factor * half_geo_cam_width,
         ),
+        bottom_left_position: bottom_left,
+        bottom_right_position: bottom_right,
+        top_right_position: Point2::new(
+            factor * ((cam_geometry.field_length / 2.0) + cam_geometry.goal_depth),
+            factor * -half_geo_cam_width,
+        ),
+        center_front_position: Point2::new(
+            factor * ((cam_geometry.field_length / 2.0)),
+            0.,
+        ),
+        center_back_position: Point2::new(
+            factor * ((cam_geometry.field_length / 2.0) + cam_geometry.goal_depth),
+            0.,
+        ),
+        front_line: Line::new(bottom_right, bottom_left),
     }
 }
 

--- a/crates/crabe_filter/src/post_filter/geometry.rs
+++ b/crates/crabe_filter/src/post_filter/geometry.rs
@@ -33,8 +33,6 @@ fn geometry_to_penalty(cam_geometry: &CamGeometry, positive: bool) -> Penalty {
             let width = 2.0 * line.line.start.y.abs();
             let depth = (line.line.start.x - line.line.end.x).abs();
             Penalty {
-                // if below looks weird to you, have a look at data/geometry.rs default values
-                // for more explanations
                 area: Rectangle::new(
                     depth, width, Point2::new(
                         factor * (cam_geometry.field_length / 2.0),

--- a/crates/crabe_filter/src/post_filter/geometry.rs
+++ b/crates/crabe_filter/src/post_filter/geometry.rs
@@ -33,8 +33,6 @@ fn geometry_to_penalty(cam_geometry: &CamGeometry, positive: bool) -> Penalty {
             let width = 2.0 * line.line.start.y.abs();
             let depth = (line.line.start.x - line.line.end.x).abs();
             Penalty {
-                width,
-                depth,
                 // if below looks weird to you, have a look at data/geometry.rs default values
                 // for more explanations
                 area: Rectangle::new(
@@ -49,8 +47,6 @@ fn geometry_to_penalty(cam_geometry: &CamGeometry, positive: bool) -> Penalty {
             let width = cam_geometry.penalty_area_width.unwrap_or(2.0);
             let depth = cam_geometry.penalty_area_depth.unwrap_or(1.0);
             Penalty {
-                width,
-                depth,
                 area: Rectangle::new(
                     depth, width, Point2::new(
                         factor * (cam_geometry.field_length / 2.0),

--- a/crates/crabe_filter/src/post_filter/geometry.rs
+++ b/crates/crabe_filter/src/post_filter/geometry.rs
@@ -66,12 +66,9 @@ fn geometry_to_goal(cam_geometry: &CamGeometry, positive: bool) -> Goal {
     Goal::new(
         cam_geometry.goal_width,
         cam_geometry.goal_depth,
-        Rectangle::new(
-            cam_geometry.goal_depth, cam_geometry.goal_width,
-            Point2::new(
-                factor * ((cam_geometry.field_length / 2.0) + cam_geometry.goal_depth),
-                factor * (cam_geometry.goal_width / 2.0),
-            ),
+        Point2::new(
+            factor * ((cam_geometry.field_length / 2.0) + cam_geometry.goal_depth),
+            factor * (cam_geometry.goal_width / 2.0),
         ), positive
     )
 }

--- a/crates/crabe_framework/src/data/geometry.rs
+++ b/crates/crabe_framework/src/data/geometry.rs
@@ -66,15 +66,11 @@ impl Default for Geometry {
                 false
             ),
             ally_penalty: Penalty {
-                width: 2.0,
-                depth: 1.0,
                 area: Rectangle::new(
                     1.0, 2.0, Point2::new(-4.5, -1.0)
                 ),
             },
             enemy_penalty: Penalty {
-                width: 2.0,
-                depth: 1.0,
                 area: Rectangle::new(
                     1.0, 2.0, Point2::new(4.5, 1.0)
                 ),

--- a/crates/crabe_framework/src/data/geometry.rs
+++ b/crates/crabe_framework/src/data/geometry.rs
@@ -47,17 +47,14 @@ impl Default for Geometry {
                 width: 6.0,
             },
 
-            // You might ask "Why is goal width not the rectangle's width here ???"
-            // To this I answer "No fucking idea"
-            // For some reason the person who chose the names for the Protobuf packet decided
-            // to call the goal 'width' the distance between the two goal posts.
-            // You can't call it 'height' because we're in a 3D world, but why didn't they
-            // call it 'length' then ?
-            //
-            // So instead we're viewing this rectangle as in 2D space, the same way a web
-            // designer would perceive it (width and height attributes in CSS).
-            // Otherwise this wouldn't make any sense, or would require new devs to understand
-            // this peculiar difference here. Let's just hide it
+            // -- this is a professional comment
+            // You might ask "Why is goal width not the rectangle's width here ?"
+            // This is because the SSL rulebook defines the penalty and goal areas with different words
+            // (from a non-programmer perspective). Recall that this is a multi-field environment.
+            // So instead we're viewing this rectangle as in 2D space in the code, the same way a web
+            // developer would perceive it (width and height attributes in CSS).
+            // Otherwise this would require new devs to understand
+            // this peculiar difference here. This is merely a choice
             ally_goal: Goal::new(
                 1.0, 0.18,
                 Rectangle::new(0.18, 1.0, Point2::new(-4.68, -0.5)),

--- a/crates/crabe_framework/src/data/geometry.rs
+++ b/crates/crabe_framework/src/data/geometry.rs
@@ -47,14 +47,6 @@ impl Default for Geometry {
                 width: 6.0,
             },
 
-            // -- this is a professional comment
-            // You might ask "Why is goal width not the rectangle's width here ?"
-            // This is because the SSL rulebook defines the penalty and goal areas with different words
-            // (from a non-programmer perspective). Recall that this is a multi-field environment.
-            // So instead we're viewing this rectangle as in 2D space in the code, the same way a web
-            // developer would perceive it (width and height attributes in CSS).
-            // Otherwise this would require new devs to understand
-            // this peculiar difference here. This is merely a choice
             ally_goal: Goal::new(
                 1.0, 0.18,
                 Point2::new(-4.68, -0.5),

--- a/crates/crabe_framework/src/data/geometry.rs
+++ b/crates/crabe_framework/src/data/geometry.rs
@@ -1,4 +1,4 @@
-use crabe_math::shape::{Circle, Line};
+use crabe_math::shape::{Circle, Line, Rectangle};
 use nalgebra::Point2;
 use serde::Serialize;
 
@@ -46,42 +46,47 @@ impl Default for Geometry {
                 length: 9.0,
                 width: 6.0,
             },
-            ally_goal: Goal {
-                width: 1.0,
-                depth: 0.18,
-                top_left_position: Point2::new(-4.68, -0.5),
-                bottom_left_position: Point2::new(-4.5, -0.5),
-                bottom_right_position: Point2::new(-4.5, 0.5),
-                top_right_position: Point2::new(-4.68, 0.5),
-                center_front_position: Point2::new(-4.5, 0.),
-                center_back_position: Point2::new(-4.68, 0.),
-                front_line: Line::new(Point2::new(-4.5, -0.5), Point2::new(-4.5, 0.5)),
-            },
-            enemy_goal: Goal {
-                width: 1.0,
-                depth: 0.18,
-                top_left_position: Point2::new(4.68, 0.5),
-                bottom_left_position: Point2::new(4.5, 0.5),
-                bottom_right_position: Point2::new(4.5, -0.5),
-                top_right_position: Point2::new(4.68, -0.5),
-                center_front_position: Point2::new(4.5, 0.),
-                center_back_position: Point2::new(4.68, 0.),
-                front_line: Line::new(Point2::new(4.5, -0.5), Point2::new(4.5, 0.5)),
-            },
+
+            // You might ask "Why is goal width not the rectangle's width here ???"
+            // To this I answer "No fucking idea"
+            // For some reason the person who chose the names for the Protobuf packet decided
+            // to call the goal 'width' the distance between the two goal posts.
+            // You can't call it 'height' because we're in a 3D world, but why didn't they
+            // call it 'length' then ?
+            //
+            // So instead we're viewing this rectangle as in 2D space, the same way a web
+            // designer would perceive it (width and height attributes in CSS).
+            // Otherwise this wouldn't make any sense, or would require new devs to understand
+            // this peculiar difference here. Let's just hide it
+            ally_goal: Goal::new(
+                1.0, 0.18,
+                Rectangle::new(0.18, 1.0, Point2::new(-4.68, -0.5)),
+                true
+            ),
+            enemy_goal: Goal::new(
+                1.0, 0.18,
+            Rectangle::new(0.18, 1.0, Point2::new(4.68, 0.5)),
+                false
+            ),
             ally_penalty: Penalty {
                 width: 2.0,
                 depth: 1.0,
-                top_left_position: Point2::new(-4.5, -1.0),
+                area: Rectangle::new(
+                    1.0, 2.0, Point2::new(-4.5, -1.0)
+                ),
             },
             enemy_penalty: Penalty {
                 width: 2.0,
                 depth: 1.0,
-                top_left_position: Point2::new(4.5, 1.0),
+                area: Rectangle::new(
+                    1.0, 2.0, Point2::new(4.5, 1.0)
+                ),
             },
             center: Circle {
                 center: Point2::new(0.0, 0.0),
                 radius: 0.5,
             },
         }
+
     }
 }

--- a/crates/crabe_framework/src/data/geometry.rs
+++ b/crates/crabe_framework/src/data/geometry.rs
@@ -1,4 +1,4 @@
-use crabe_math::shape::Circle;
+use crabe_math::shape::{Circle, Line};
 use nalgebra::Point2;
 use serde::Serialize;
 
@@ -50,11 +50,19 @@ impl Default for Geometry {
                 width: 1.0,
                 depth: 0.18,
                 top_left_position: Point2::new(-4.68, -0.5),
+                bottom_left_position: Point2::new(-4.5, -0.5),
+                bottom_right_position: Point2::new(-4.5, 0.5),
+                top_right_position: Point2::new(-4.68, 0.5),
+                front_line: Line::new(Point2::new(-4.5, -0.5), Point2::new(-4.5, 0.5)),
             },
             enemy_goal: Goal {
                 width: 1.0,
                 depth: 0.18,
                 top_left_position: Point2::new(4.68, 0.5),
+                bottom_left_position: Point2::new(4.5, 0.5),
+                bottom_right_position: Point2::new(4.5, -0.5),
+                top_right_position: Point2::new(4.68, -0.5),
+                front_line: Line::new(Point2::new(4.5, -0.5), Point2::new(4.5, 0.5)),
             },
             ally_penalty: Penalty {
                 width: 2.0,

--- a/crates/crabe_framework/src/data/geometry.rs
+++ b/crates/crabe_framework/src/data/geometry.rs
@@ -57,12 +57,12 @@ impl Default for Geometry {
             // this peculiar difference here. This is merely a choice
             ally_goal: Goal::new(
                 1.0, 0.18,
-                Rectangle::new(0.18, 1.0, Point2::new(-4.68, -0.5)),
+                Point2::new(-4.68, -0.5),
                 true
             ),
             enemy_goal: Goal::new(
                 1.0, 0.18,
-            Rectangle::new(0.18, 1.0, Point2::new(4.68, 0.5)),
+            Point2::new(4.68, 0.5),
                 false
             ),
             ally_penalty: Penalty {

--- a/crates/crabe_framework/src/data/geometry.rs
+++ b/crates/crabe_framework/src/data/geometry.rs
@@ -53,6 +53,8 @@ impl Default for Geometry {
                 bottom_left_position: Point2::new(-4.5, -0.5),
                 bottom_right_position: Point2::new(-4.5, 0.5),
                 top_right_position: Point2::new(-4.68, 0.5),
+                center_front_position: Point2::new(-4.5, 0.),
+                center_back_position: Point2::new(-4.68, 0.),
                 front_line: Line::new(Point2::new(-4.5, -0.5), Point2::new(-4.5, 0.5)),
             },
             enemy_goal: Goal {
@@ -62,6 +64,8 @@ impl Default for Geometry {
                 bottom_left_position: Point2::new(4.5, 0.5),
                 bottom_right_position: Point2::new(4.5, -0.5),
                 top_right_position: Point2::new(4.68, -0.5),
+                center_front_position: Point2::new(4.5, 0.),
+                center_back_position: Point2::new(4.68, 0.),
                 front_line: Line::new(Point2::new(4.5, -0.5), Point2::new(4.5, 0.5)),
             },
             ally_penalty: Penalty {

--- a/crates/crabe_framework/src/data/geometry/goal.rs
+++ b/crates/crabe_framework/src/data/geometry/goal.rs
@@ -1,5 +1,5 @@
-use crabe_math::shape::Line;
 use nalgebra::Point2;
+use crabe_math::shape::{Line, Rectangle};
 use serde::Serialize;
 
 /// Represents a goal on a soccer field.
@@ -10,27 +10,47 @@ pub struct Goal {
     pub width: f64,
     /// The depth of the goal, in meters.
     pub depth: f64,
-    /// The top-left corner of the goal, measured from the origin of the field,
-    /// in meters.
-    pub top_left_position: Point2<f64>,
-    /// The bottom-left corner of the goal, measured from the origin of the field,
-    /// in meters.
-    pub bottom_left_position: Point2<f64>,
-    /// The bottom-right corner of the goal, measured from the origin of the field,
-    /// in meters.
-    pub bottom_right_position: Point2<f64>,
-    /// The top-right corner of the goal, measured from the origin of the field,
-    /// in meters.
-    pub top_right_position: Point2<f64>,
-    // The center front point of the goal, measured from the origin of the field,
-    /// in meters.
-    pub center_front_position: Point2<f64>,
-    // The center back point of the goal, measured from the origin of the field,
-    /// in meters.
-    pub center_back_position: Point2<f64>,
+    /// Describes the 4 points of the goal area, in meters
+    pub area: Rectangle,
+    /// Center of the goal, starts from the front of the goal to its inside, parallel to the goal posts
+    pub center_line: Line,
     /// The front line of the goal, measured from the origin of the field,
     /// in meters.
-    pub front_line: Line
+    pub front_line: Line,
 }
 
-impl Goal {}
+impl Goal {
+    pub fn new(width: f64, depth: f64, area: Rectangle, positive: bool) -> Goal {
+
+        let front_line: Line;
+        let center_line: Line;
+
+        if positive {
+            center_line = Line {
+                start: Point2::new(area.center.x + depth, area.center.y + depth),
+                end: Point2::new(area.center.x - depth, area.center.y - depth),
+            };
+            front_line = Line {
+                start: area.top_left,
+                end: area.bottom_left
+            }
+        } else {
+            center_line = Line {
+                start: Point2::new(area.center.x - depth, area.center.y - depth),
+                end: Point2::new(area.center.x + depth, area.center.y + depth),
+            };
+            front_line = Line {
+                start: area.top_right,
+                end: area.bottom_right
+            }
+        };
+
+        Self {
+            width,
+            depth,
+            area,
+            center_line,
+            front_line,
+        }
+    }
+}

--- a/crates/crabe_framework/src/data/geometry/goal.rs
+++ b/crates/crabe_framework/src/data/geometry/goal.rs
@@ -31,7 +31,7 @@ impl Goal {
             };
             front_line = Line {
                 start: area.top_left,
-                end: area.bottom_left
+                end: area.bottom_left()
             }
         } else {
             center_line = Line {
@@ -39,8 +39,8 @@ impl Goal {
                 end: Point2::new(area.center.x + depth, area.center.y + depth),
             };
             front_line = Line {
-                start: area.top_right,
-                end: area.bottom_right
+                start: area.top_right(),
+                end: area.bottom_right()
             }
         };
 

--- a/crates/crabe_framework/src/data/geometry/goal.rs
+++ b/crates/crabe_framework/src/data/geometry/goal.rs
@@ -1,10 +1,10 @@
 use nalgebra::Point2;
 use crabe_math::shape::{Line, Rectangle};
-use serde::Serialize;
+use serde::{Serialize, Serializer};
+use serde::ser::SerializeStruct;
 
 /// Represents a goal on a soccer field.
-#[derive(Serialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug)]
 pub struct Goal {
     /// Describes the 4 points of the goal area, in meters
     pub area: Rectangle,
@@ -53,11 +53,25 @@ impl Goal {
 
     /// The width of the goal, in meters, as defined per the SSL rulebook
     pub fn width(&self) -> &f64 {
-        return &self.area.height;
+         &self.area.height
     }
 
     /// The depth of the goal, in meters, as defined per the SSL rulebook
     pub fn depth(&self) -> &f64 {
-        return &self.area.width;
+        &self.area.width
+    }
+}
+
+impl Serialize for Goal {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        let num_fields: usize = 3;
+        let mut state
+            = serializer.serialize_struct("Goal", num_fields)?;
+        state.serialize_field("width", &self.area.height)?;
+        state.serialize_field("depth", &self.area.width)?;
+        state.serialize_field("topLeftPosition", &self.area.top_left)?;
+        state.end()
     }
 }

--- a/crates/crabe_framework/src/data/geometry/goal.rs
+++ b/crates/crabe_framework/src/data/geometry/goal.rs
@@ -6,22 +6,21 @@ use serde::Serialize;
 #[derive(Serialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Goal {
-    /// The width of the goal, in meters.
-    pub width: f64,
-    /// The depth of the goal, in meters.
-    pub depth: f64,
     /// Describes the 4 points of the goal area, in meters
     pub area: Rectangle,
     /// Center of the goal, starts from the front of the goal to its inside, parallel to the goal posts
     pub center_line: Line,
-    /// The front line of the goal, measured from the origin of the field,
-    /// in meters.
+    /// The front line of the goal, measured from the origin of the field, in meters.
     pub front_line: Line,
 }
 
 impl Goal {
-    pub fn new(width: f64, depth: f64, area: Rectangle, positive: bool) -> Goal {
+    pub fn new(goal_width: f64, goal_depth: f64, top_left_position: Point2<f64>, positive: bool) -> Goal {
+        let area = Rectangle::new(
+            goal_depth, goal_width, top_left_position
+        );
 
+        let depth = area.width;
         let front_line: Line;
         let center_line: Line;
 
@@ -46,11 +45,19 @@ impl Goal {
         };
 
         Self {
-            width,
-            depth,
             area,
             center_line,
             front_line,
         }
+    }
+
+    /// The width of the goal, in meters, as defined per the SSL rulebook
+    pub fn width(&self) -> &f64 {
+        return &self.area.height;
+    }
+
+    /// The depth of the goal, in meters, as defined per the SSL rulebook
+    pub fn depth(&self) -> &f64 {
+        return &self.area.width;
     }
 }

--- a/crates/crabe_framework/src/data/geometry/goal.rs
+++ b/crates/crabe_framework/src/data/geometry/goal.rs
@@ -1,3 +1,4 @@
+use crabe_math::shape::Line;
 use nalgebra::Point2;
 use serde::Serialize;
 
@@ -12,6 +13,18 @@ pub struct Goal {
     /// The top-left corner of the goal, measured from the origin of the field,
     /// in meters.
     pub top_left_position: Point2<f64>,
+    /// The bottom-left corner of the goal, measured from the origin of the field,
+    /// in meters.
+    pub bottom_left_position: Point2<f64>,
+    /// The bottom-right corner of the goal, measured from the origin of the field,
+    /// in meters.
+    pub bottom_right_position: Point2<f64>,
+    /// The top-right corner of the goal, measured from the origin of the field,
+    /// in meters.
+    pub top_right_position: Point2<f64>,
+    /// The front line of the goal, measured from the origin of the field,
+    /// in meters.
+    pub front_line: Line
 }
 
 impl Goal {}

--- a/crates/crabe_framework/src/data/geometry/goal.rs
+++ b/crates/crabe_framework/src/data/geometry/goal.rs
@@ -22,6 +22,12 @@ pub struct Goal {
     /// The top-right corner of the goal, measured from the origin of the field,
     /// in meters.
     pub top_right_position: Point2<f64>,
+    // The center front point of the goal, measured from the origin of the field,
+    /// in meters.
+    pub center_front_position: Point2<f64>,
+    // The center back point of the goal, measured from the origin of the field,
+    /// in meters.
+    pub center_back_position: Point2<f64>,
     /// The front line of the goal, measured from the origin of the field,
     /// in meters.
     pub front_line: Line

--- a/crates/crabe_framework/src/data/geometry/penalty.rs
+++ b/crates/crabe_framework/src/data/geometry/penalty.rs
@@ -1,16 +1,34 @@
-use serde::Serialize;
+use serde::{Serialize, Serializer};
+use serde::ser::SerializeStruct;
 use crabe_math::shape::Rectangle;
 
 /// Represents a penalty area on a soccer field.
-#[derive(Serialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug)]
 pub struct Penalty {
-    /// The width of the penalty area in meters.
-    pub width: f64,
-    /// The depth of the penalty area in meters.
-    pub depth: f64,
     /// The area covered by this penalty zone
     pub area: Rectangle,
 }
 
-impl Penalty {}
+impl Penalty {
+    /// The width of the penalty area in meters, as per the SSL rulebook.
+    pub fn width(&self) -> &f64 {
+        &self.area.height
+    }
+
+    /// The depth of the penalty area in meters, as per the SSL rulebook.
+    pub fn depth(&self) -> &f64 {
+        &self.area.width
+    }
+}
+
+impl Serialize for Penalty {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+        let num_fields: usize = 3;
+        let mut state =
+            serializer.serialize_struct("Penalty", num_fields)?;
+        state.serialize_field("width", &self.width())?;
+        state.serialize_field("depth", &self.depth())?;
+        state.serialize_field("topLeftPosition", &self.area.top_left)?;
+        state.end()
+    }
+}

--- a/crates/crabe_framework/src/data/geometry/penalty.rs
+++ b/crates/crabe_framework/src/data/geometry/penalty.rs
@@ -1,5 +1,5 @@
-use nalgebra::Point2;
 use serde::Serialize;
+use crabe_math::shape::Rectangle;
 
 /// Represents a penalty area on a soccer field.
 #[derive(Serialize, Clone, Debug)]
@@ -9,9 +9,8 @@ pub struct Penalty {
     pub width: f64,
     /// The depth of the penalty area in meters.
     pub depth: f64,
-    /// The top-left corner of the penalty area, measured from the origin of the
-    /// field, in meters.
-    pub top_left_position: Point2<f64>,
+    /// The area covered by this penalty zone
+    pub area: Rectangle,
 }
 
 impl Penalty {}

--- a/crates/crabe_math/src/shape/rectangle.rs
+++ b/crates/crabe_math/src/shape/rectangle.rs
@@ -23,12 +23,6 @@ pub struct Rectangle {
     pub height: f64,
     /// The position of the rectangle's top-left corner.
     pub top_left: Point2<f64>,
-    /// The position of the rectangle's top-right corner.
-    pub top_right: Point2<f64>,
-    /// The position of the rectangle's bottom-left corner.
-    pub bottom_left: Point2<f64>,
-    /// The position of the rectangle's bottom-right corner.
-    pub bottom_right: Point2<f64>,
     /// The position of the rectangle's center.
     pub center: Point2<f64>,
 }
@@ -40,10 +34,19 @@ impl Rectangle {
             width,
             height,
             top_left,
-            top_right: Point2::new(top_left.x + width, top_left.y),
-            bottom_left: Point2::new(top_left.x, top_left.y - height),
-            bottom_right: Point2::new(top_left.x + width, top_left.y - height),
             center: Point2::new(top_left.x + (width / 2.), top_left.y - (height / 2.)),
         }
+    }
+
+    pub fn top_right(&self) -> Point2<f64> {
+        Point2::new(self.top_left.x + self.width, self.top_left.y)
+    }
+
+    pub fn bottom_right(&self) -> Point2<f64> {
+        Point2::new(self.top_left.x + self.width, self.top_left.y - self.height)
+    }
+
+    pub fn bottom_left(&self) -> Point2<f64> {
+        Point2::new(self.top_left.x, self.top_left.y - self.height)
     }
 }

--- a/crates/crabe_math/src/shape/rectangle.rs
+++ b/crates/crabe_math/src/shape/rectangle.rs
@@ -1,10 +1,19 @@
-use nalgebra::Point2;
+use nalgebra::{Point2};
 use serde::Serialize;
 
 /// A rectangle in 2D space, defined by a width, a height, and a position.
-///
+/// 
 /// Note that the `width` and `height` fields should have the same units of
 /// measurement as the coordinates of the `position` field.
+///
+/// The base (in French: repère) is defined as follows :
+/// ```txt
+/// * -- -- -- >
+/// |          x
+/// |
+/// |
+/// v y
+/// ```
 #[derive(Clone, Serialize, Debug)]
 pub struct Rectangle {
     /// The width of the rectangle.
@@ -12,5 +21,28 @@ pub struct Rectangle {
     /// The height of the rectangle.
     pub height: f64,
     /// The position of the rectangle's top-left corner.
-    pub position: Point2<f64>,
+    pub top_left: Point2<f64>,
+    /// The position of the rectangle's top-right corner.
+    pub top_right: Point2<f64>,
+    /// The position of the rectangle's bottom-left corner.
+    pub bottom_left: Point2<f64>,
+    /// The position of the rectangle's bottom-right corner.
+    pub bottom_right: Point2<f64>,
+    /// The position of the rectangle's center.
+    pub center: Point2<f64>,
+}
+
+impl Rectangle {
+    /// Creates a new Rectangle by using the top-left Point2 as the reference
+    pub fn new(width: f64, height: f64, top_left: Point2<f64>) -> Rectangle {
+        Rectangle {
+            width,
+            height,
+            top_left,
+            top_right: Point2::new(top_left.x + width, top_left.y),
+            bottom_left: Point2::new(top_left.x, top_left.y - height),
+            bottom_right: Point2::new(top_left.x + width, top_left.y - height),
+            center: Point2::new(top_left.x + (width / 2.), top_left.y - (height / 2.)),
+        }
+    }
 }

--- a/crates/crabe_math/src/shape/rectangle.rs
+++ b/crates/crabe_math/src/shape/rectangle.rs
@@ -15,6 +15,7 @@ use serde::Serialize;
 /// v y
 /// ```
 #[derive(Clone, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct Rectangle {
     /// The width of the rectangle.
     pub width: f64,


### PR DESCRIPTION
Instead of having points in the struct, the structures `Penalty` and `Goal` use instead the struct `Rectangle` to define these points.
Additionally, the original attributes have been kept so that the viewer [(aquarium)](https://github.com/NAMeC-SSL/aquarium) can still display properly what it receives.

This PR requires some additional changes on aquarium, which have been addressed by a new branch on its repository [(crabe-refac-shapes)](https://github.com/NAMeC-SSL/aquarium/tree/crabe-refac-shapes).

there are some weird twists in the code, notably because of notation issues. looks messy but I tried my best, looking for advice on how to improve this