### PR TITLE
Revamped state machine for matches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,9 +214,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -224,7 +224,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.48.0",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -1886,6 +1886,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1896,6 +1912,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1910,6 +1932,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,6 +1948,18 @@ name = "windows_i686_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1934,6 +1974,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1944,6 +1990,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1958,6 +2010,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1968,3 +2026,9 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,6 +338,7 @@ dependencies = [
  "clap",
  "crabe_math",
  "crabe_protocol",
+ "log",
  "nalgebra",
  "serde",
  "serde_json",
@@ -864,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "mach"

--- a/crates/crabe_filter/src/data.rs
+++ b/crates/crabe_filter/src/data.rs
@@ -1,5 +1,7 @@
 pub mod camera;
 
+pub mod referee;
+
 use crate::constant;
 use crate::data::camera::{CamBall, CamGeometry, CamRobot};
 use chrono::{DateTime, Utc};
@@ -8,6 +10,7 @@ use crabe_framework::data::world::{AllyInfo, Ball, EnemyInfo, Robot};
 use ringbuffer::ConstGenericRingBuffer;
 use std::collections::HashMap;
 use std::time::Instant;
+use crate::data::referee::Referee;
 
 #[derive(Clone, Debug)]
 pub struct FrameInfo {
@@ -18,13 +21,34 @@ pub struct FrameInfo {
 
 pub type TrackedRobotMap<T> = HashMap<u8, TrackedRobot<T>>;
 
+/// Collection of transformed data from external
+/// sources into our own structures
 pub struct FilterData {
+    /// Map associating a robot id to its data, for allies only
     pub allies: TrackedRobotMap<AllyInfo>,
+    /// Map associating a robot id to its data, for enemies only
     pub enemies: TrackedRobotMap<EnemyInfo>,
+    /// Data about the ball on the field
     pub ball: TrackedBall,
+    /// Information on the field geometry
     pub geometry: CamGeometry,
+    /// Game controller events
+    pub referee: Vec<Referee>,
 }
 
+impl Default for FilterData {
+    fn default() -> Self {
+        FilterData {
+            allies: Default::default(),
+            enemies: Default::default(),
+            ball: Default::default(),
+            geometry: Default::default(),
+                referee: vec![],
+        }
+    }
+}
+
+/// Contains data bout a robot detected on the field
 pub struct TrackedRobot<T> {
     pub packets: ConstGenericRingBuffer<CamRobot, PACKET_BUFFER_SIZE>,
     pub data: Robot<T>,
@@ -41,6 +65,10 @@ impl<T: Default> Default for TrackedRobot<T> {
     }
 }
 
+/// Contains data about the ball detected on the field
+/// Note that there might be multiple instances of this
+/// struct in the system (the vision is able to watch
+/// multiple balls on the field)
 pub struct TrackedBall {
     pub packets: ConstGenericRingBuffer<CamBall, PACKET_BUFFER_SIZE>,
     pub data: Ball,

--- a/crates/crabe_filter/src/data.rs
+++ b/crates/crabe_filter/src/data.rs
@@ -1,7 +1,5 @@
 pub mod camera;
 
-pub mod referee;
-
 use crate::constant;
 use crate::data::camera::{CamBall, CamGeometry, CamRobot};
 use chrono::{DateTime, Utc};
@@ -10,7 +8,7 @@ use crabe_framework::data::world::{AllyInfo, Ball, EnemyInfo, Robot};
 use ringbuffer::ConstGenericRingBuffer;
 use std::collections::HashMap;
 use std::time::Instant;
-use crate::data::referee::Referee;
+use crabe_framework::data::referee::Referee;
 
 #[derive(Clone, Debug)]
 pub struct FrameInfo {

--- a/crates/crabe_filter/src/data/referee.rs
+++ b/crates/crabe_filter/src/data/referee.rs
@@ -1,0 +1,186 @@
+use chrono::{DateTime, Duration, Utc};
+use crabe_framework::data::world::TeamColor;
+use event::GameEvent;
+use nalgebra::Point2;
+
+pub mod event;
+
+/// MatchType is a meta information about the current match for easier log processing.
+#[derive(
+    Clone,
+    Copy,
+    Debug
+)]
+#[repr(i32)]
+pub enum MatchType {
+    /// Not set
+    UnknownMatch = 0,
+    /// Match is part of the group phase
+    GroupPhase = 1,
+    /// Match is part of the elimination phase
+    EliminationPhase = 2,
+    /// Friendly match, not part of a tournament
+    Friendly = 3,
+}
+
+/// The `Referee` struct contains various information about the referee of a match.
+#[derive(Clone, Debug)]
+pub struct Referee {
+    /// A random UUID of the referee that is kept constant while running.
+    pub source_identifier: Option<String>,
+    /// Meta information about the current match that helps to process the logs after a competition.
+    pub match_type: Option<MatchType>,
+    /// The UNIX timestamp when the packet was sent, in microseconds.
+    pub packet_timestamp: DateTime<Utc>,
+    /// Represent the "coarse" stages of the match.
+    pub stage: Stage,
+    /// The number of microseconds left in the stage.
+    /// Some stage have this value :
+    /// - NORMAL_FIRST_HALF, NORMAL_HALF_TIME, NORMAL_SECOND_HALF
+    /// - EXTRA_TIME_BREAK EXTRA_FIRST_HALF EXTRA_HALF_TIME EXTRA_SECOND_HALF
+    /// - PENALTY_SHOOTOUT_BREAK
+    /// If the stage runs over its specified time, this value becomes negative.
+    pub stage_time_left: Option<Duration>,
+    /// These are the "fine" states of play on the field..
+    pub command: RefereeCommand,
+    /// The number of commands issued since startup (mod 2^32).
+    pub command_counter: u32,
+    /// The UNIX timestamp when the command was issued, in microseconds.
+    pub command_timestamp: DateTime<Utc>,
+    /// Information about the ally team.
+    pub ally: TeamInfo,
+    /// Information about the enemy team.
+    pub enemy: TeamInfo,
+    /// The coordinates of the designated Position (in millimeters).
+    /// Use only in the case of a ball placement command.
+    pub designated_position: Option<Point2<f64>>,
+    /// Information about the direction of play.
+    /// True, if the blue team will have it's goal on the positive x-axis of the ssl-vision coordinate system.
+    /// Obviously, the yellow team will play on the opposite half.
+    pub positive_half: Option<TeamColor>,
+    /// The command that will be issued after the current stoppage and ball placement to continue the game.
+    pub next_command: Option<RefereeCommand>,
+    /// All game events that were detected since the last RUNNING state.
+    /// Will be cleared as soon as the game is continued.
+    pub game_events: Vec<GameEvent>,
+    /// All non-finished proposed game events that may be processed next.
+    pub game_event_proposals: Vec<GameEventProposalGroup>,
+    /// The time in microseconds that is remaining until the current action times out
+    /// The time will not be reset. It can get negative.
+    /// Possible actions where this time is relevant:
+    /// - free kicks
+    /// - kickoff, penalty kick, force start
+    /// - ball placement
+    pub current_action_time_remaining: Option<Duration>,
+}
+
+/// List of matching proposals.
+#[derive(Clone, Debug)]
+pub struct GameEventProposalGroup {
+    /// The proposed game event.
+    pub game_event: Vec<GameEvent>,
+    /// Whether the proposal group was accepted.
+    pub accepted: Option<bool>,
+}
+/// `Stage` represents different stages of a game.
+#[derive(Clone, Debug)]
+#[repr(i32)]
+pub enum Stage {
+    /// Indicates that the first half is about to start.
+    NormalFirstHalfPre = 0,
+    /// Indicates the first half of the normal game, before half time.
+    NormalFirstHalf = 1,
+    /// Indicates the half time period between the first and second halves.
+    NormalHalfTime = 2,
+    /// Indicates that the second half is about to start.
+    NormalSecondHalfPre = 3,
+    /// Indicates the second half of the normal game, after half time.
+    NormalSecondHalf = 4,
+    /// Represents the break before extra time.
+    ExtraTimeBreak = 5,
+    /// Indicates that the first half of the extra time is about to start.
+    ExtraFirstHalfPre = 6,
+    /// Represents the first half of the extra time.
+    ExtraFirstHalf = 7,
+    /// Indicates the half time period between the first and second extra halves.
+    ExtraHalfTime = 8,
+    /// Indicates that the second half of extra time is about to start.
+    ExtraSecondHalfPre = 9,
+    /// Represents the second half of the extra time.
+    ExtraSecondHalf = 10,
+    /// Represents the break period before the penalty shootout.
+    PenaltyShootoutBreak = 11,
+    /// Represents the penalty shootout stage.
+    PenaltyShootout = 12,
+    /// Indicates that the game has ended.
+    PostGame = 13,
+}
+
+/// The `RefereeCommand` enum represents a set of possible commands that a referee can issue during a game.
+/// These commands control the state of the game and dictate the actions that robots are allowed to perform at any given moment.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RefereeCommand {
+    /// Command indicating that all robots must halt movement immediately.
+    Halt,
+    /// Command instructing robots to maintain a distance of at least 50 cm from the ball.
+    Stop,
+    /// Command allowing a team to proceed with a prepared kickoff or penalty shot.
+    NormalStart,
+    /// Command declaring that the ball is freely accessible to any team, typically after a halt.
+    ForceStart,
+    /// Command allowing the specified team to move into position for a kickoff.
+    PrepareKickoff(TeamColor),
+    /// Command allowing the specified team to move into position for a penalty shot.
+    PreparePenalty(TeamColor),
+    /// Command allowing the specified team to take a direct free kick.
+    DirectFree(TeamColor),
+    /// Command allowing the specified team to take an indirect free kick.
+    IndirectFree(TeamColor),
+    /// Command indicating that the specified team has requested a timeout.
+    Timeout(TeamColor),
+    /// Deprecated: This command indicates the specified team has scored a goal.
+    /// It's recommended to use the score field from the team infos instead for goal detection and revoked goals.
+    Goal(TeamColor),
+    /// Command equivalent to `Stop`, but the specified team must retrieve the ball and place it in a designated position.
+    BallPlacement(TeamColor),
+    ///Deprecated state
+    Deprecated,
+}
+
+/// Information about a single team.
+#[derive(Clone, Debug)]
+pub struct TeamInfo {
+    /// The team's name (empty string if operator has not typed anything).
+    pub name: String,
+    /// The number of goals scored by the team during normal play and overtime.
+    pub score: u32,
+    /// The number of red cards issued to the team since the beginning of the game.
+    pub red_cards: u32,
+    /// The amount of time (in microseconds) left on each yellow card issued to the team.
+    /// If no yellow cards are issued, this array has no elements.
+    /// Otherwise, times are ordered from smallest to largest.
+    pub yellow_card_times: Vec<u32>,
+    /// The total number of yellow cards ever issued to the team.
+    pub yellow_cards: u32,
+    /// The number of timeouts this team can still call.
+    /// If in a timeout right now, that timeout is excluded.
+    pub timeouts: u32,
+    /// The number of microseconds of timeout this team can use.
+    pub timeout_time: u32,
+    /// The pattern number of this team's goalkeeper.
+    pub goalkeeper: u32,
+    /// The total number of countable fouls that act towards yellow cards
+    pub foul_counter: Option<u32>,
+    /// The number of consecutive ball placement failures of this team
+    pub ball_placement_failures: Option<u32>,
+    /// Indicate if the team is able and allowed to place the ball
+    pub can_place_ball: Option<bool>,
+    /// The maximum number of bots allowed on the field based on division and cards
+    pub max_allowed_bots: Option<u32>,
+    /// The team has submitted an intent to substitute one or more robots at the next chance
+    pub bot_substitution_intent: Option<bool>,
+    /// Indicate if the team reached the maximum allowed ball placement failures and is thus not allowed to place the ball anymore
+    pub ball_placement_failures_reached: Option<bool>,
+    /// The team is allowed to substitute one or more robots currently
+    pub bot_substitution_allowed: Option<bool>,
+}

--- a/crates/crabe_filter/src/data/referee/event.rs
+++ b/crates/crabe_filter/src/data/referee/event.rs
@@ -1,0 +1,539 @@
+use chrono::Duration;
+use crabe_framework::data::world::TeamColor;
+use crabe_protocol::protobuf::game_controller_packet;
+use crabe_protocol::protobuf::game_controller_packet::game_event::Type;
+use nalgebra::Point2;
+
+/// GameEvent contains exactly one game event.
+/// Each game event has optional and required fields.
+#[derive(Clone, Debug)]
+pub struct GameEvent {
+    /// Event type of this Game
+    pub type_event: Option<GameEventType>,
+    /// The origins of this game event.
+    /// Empty, if it originates from game controller.
+    pub origin: Vec<EventOrigin>,
+    /// Unix timestamp in microseconds when the event was created.
+    pub created_timestamp: Option<u64>,
+    /// the event that occurred
+    pub event: Event,
+}
+
+impl From<game_controller_packet::GameEvent> for GameEvent {
+    fn from(packet: game_controller_packet::GameEvent) -> Self {
+        Self {
+            type_event: Option::from(GameEventType::from(packet.r#type())),
+            origin: vec![],
+            created_timestamp: None,
+            event: Event::DeprecatedEvent,
+        }
+    }
+}
+
+/// All game event type.
+/// See the protobuf message inside the crate `crabe_protocol` to see which game event is triggered by gc, auto_referee and human.
+#[derive(Clone, Debug)]
+pub enum GameEventType {
+    Unknown,
+    BallLeftFieldTouchLine,
+    BallLeftFieldGoalLine,
+    AimlessKick,
+    AttackerTooCloseToDefenseArea,
+    DefenderInDefenseArea,
+    BoundaryCrossing,
+    KeeperHeldBall,
+    BotDribbledBallTooFar,
+    BotPushedBot,
+    BotHeldBallDeliberately,
+    BotTippedOver,
+    AttackerTouchedBallInDefenseArea,
+    BotKickedBallTooFast,
+    BotCrashUnique,
+    BotCrashDrawn,
+    DefenderTooCloseToKickPoint,
+    BotTooFastInStop,
+    BotInterferedPlacement,
+    PossibleGoal,
+    Goal,
+    InvalidGoal,
+    AttackerDoubleTouchedBall,
+    PlacementSucceeded,
+    PenaltyKickFailed,
+    NoProgressInGame,
+    PlacementFailed,
+    MultipleCards,
+    MultipleFouls,
+    BotSubstitution,
+    TooManyRobots,
+    ChallengeFlag,
+    ChallengeFlagHandled,
+    EmergencyStop,
+    UnsportingBehaviorMinor,
+    UnsportingBehaviorMajor,
+    Deprecated,
+}
+
+impl From<Type> for GameEventType {
+    fn from(packet: Type) -> Self {
+        match packet {
+            Type::UnknownGameEventType => GameEventType::Unknown,
+            Type::BallLeftFieldTouchLine => GameEventType::BallLeftFieldTouchLine,
+            Type::BallLeftFieldGoalLine => GameEventType::BallLeftFieldGoalLine,
+            Type::AimlessKick => GameEventType::AimlessKick,
+            Type::AttackerTooCloseToDefenseArea => GameEventType::AttackerTooCloseToDefenseArea,
+            Type::DefenderInDefenseArea => GameEventType::DefenderInDefenseArea,
+            Type::BoundaryCrossing => GameEventType::BoundaryCrossing,
+            Type::KeeperHeldBall => GameEventType::KeeperHeldBall,
+            Type::BotDribbledBallTooFar => GameEventType::BotDribbledBallTooFar,
+            Type::BotPushedBot => GameEventType::BotPushedBot,
+            Type::BotHeldBallDeliberately => GameEventType::BotHeldBallDeliberately,
+            Type::BotTippedOver => GameEventType::BotTippedOver,
+            Type::AttackerTouchedBallInDefenseArea => {
+                GameEventType::AttackerTouchedBallInDefenseArea
+            }
+            Type::BotKickedBallTooFast => GameEventType::BotKickedBallTooFast,
+            Type::BotCrashUnique => GameEventType::BotCrashUnique,
+            Type::BotCrashDrawn => GameEventType::BotCrashDrawn,
+            Type::DefenderTooCloseToKickPoint => GameEventType::DefenderTooCloseToKickPoint,
+            Type::BotTooFastInStop => GameEventType::BotTooFastInStop,
+            Type::BotInterferedPlacement => GameEventType::BotInterferedPlacement,
+            Type::PossibleGoal => GameEventType::PossibleGoal,
+            Type::Goal => GameEventType::Goal,
+            Type::InvalidGoal => GameEventType::InvalidGoal,
+            Type::AttackerDoubleTouchedBall => GameEventType::AttackerDoubleTouchedBall,
+            Type::PlacementSucceeded => GameEventType::PlacementSucceeded,
+            Type::PenaltyKickFailed => GameEventType::PenaltyKickFailed,
+            Type::NoProgressInGame => GameEventType::NoProgressInGame,
+            Type::PlacementFailed => GameEventType::PlacementFailed,
+            Type::MultipleCards => GameEventType::MultipleCards,
+            Type::MultipleFouls => GameEventType::MultipleFouls,
+            Type::BotSubstitution => GameEventType::BotSubstitution,
+            Type::TooManyRobots => GameEventType::TooManyRobots,
+            Type::ChallengeFlag => GameEventType::ChallengeFlag,
+            Type::ChallengeFlagHandled => GameEventType::ChallengeFlagHandled,
+            Type::EmergencyStop => GameEventType::EmergencyStop,
+            Type::UnsportingBehaviorMinor => GameEventType::UnsportingBehaviorMinor,
+            Type::UnsportingBehaviorMajor => GameEventType::UnsportingBehaviorMajor,
+            Type::Prepared => GameEventType::Deprecated,
+            Type::IndirectGoal => GameEventType::Deprecated,
+            Type::ChippedGoal => GameEventType::Deprecated,
+            Type::KickTimeout => GameEventType::Deprecated,
+            Type::AttackerTouchedOpponentInDefenseArea => GameEventType::Deprecated,
+            Type::AttackerTouchedOpponentInDefenseAreaSkipped => GameEventType::Deprecated,
+            Type::BotCrashUniqueSkipped => GameEventType::Deprecated,
+            Type::BotPushedBotSkipped => GameEventType::Deprecated,
+            Type::DefenderInDefenseAreaPartially => GameEventType::Deprecated,
+            Type::MultiplePlacementFailures => GameEventType::Deprecated,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum Event {
+    // Ball out of field events (Stopping)
+    BallLeftFieldTouchLine(BallLeftField),
+    BallLeftFieldGoalLine(BallLeftField),
+    AimlessKick(AimlessKick),
+
+    // Stopping fouls
+    AttackerTooCloseToDefenseArea(AttackerTooCloseToDefenseArea),
+    DefenderInDefenseArea(DefenderInDefenseArea),
+    BoundaryCrossing(BoundaryCrossing),
+    KeeperHeldBall(KeeperHeldBall),
+    BotDribbledBallTooFar(BotDribbledBallTooFar),
+
+    BotPushedBot(BotPushedBot),
+    BotHeldBallDeliberately(BotHeldBallDeliberately),
+    BotTippedOver(BotTippedOver),
+
+    // Non-Stopping Fouls
+    AttackerTouchedBallInDefenseArea(AttackerTouchedBallInDefenseArea),
+    BotKickedBallTooFast(BotKickedBallTooFast),
+    BotCrashUnique(BotCrashUnique),
+    BotCrashDrawn(BotCrashDrawn),
+
+    // Fouls while ball out of play
+    DefenderTooCloseToKickPoint(DefenderTooCloseToKickPoint),
+    BotTooFastInStop(BotTooFastInStop),
+    BotInterferedPlacement(BotInterferedPlacement),
+
+    // Scoring goals
+    PossibleGoal(Goal),
+    Goal(Goal),
+    InvalidGoal(Goal),
+
+    // Other events
+    AttackerDoubleTouchedBall(AttackerDoubleTouchedBall),
+    PlacementSucceeded(PlacementSucceeded),
+    PenaltyKickFailed(PenaltyKickFailed),
+
+    NoProgressInGame(NoProgressInGame),
+    PlacementFailed(PlacementFailed),
+    MultipleCards(TeamColor),
+    MultipleFouls(MultipleFouls),
+    TooManyRobots(TooManyRobots),
+    BotSubstitution(TeamColor),
+    ChallengeFlag(TeamColor),
+    EmergencyStop(TeamColor),
+    UnsportingBehaviorMinor(UnsportingBehaviorMinor),
+    UnsportingBehaviorMajor(UnsportingBehaviorMajor),
+
+    DeprecatedEvent,
+}
+
+//////////////////////////////////////////////////////
+//               Event Struct Type                  //
+//////////////////////////////////////////////////////
+
+/// Represents an event where the ball left the field normally.
+#[derive(Clone, Debug)]
+pub struct BallLeftField {
+    /// The team that last touched the ball.
+    pub by_team: TeamColor,
+    /// The bot that last touched the ball.
+    pub by_bot: Option<u32>,
+    /// The location where the ball left the field (in meter).
+    pub location: Option<Point2<f64>>,
+}
+
+/// Represents an event where the ball left the field via goal line and a team committed an aimless kick.
+#[derive(Clone, Debug)]
+pub struct AimlessKick {
+    /// The team that last touched the ball
+    pub by_team: TeamColor,
+    /// The bot that last touched the ball.
+    pub by_bot: Option<u32>,
+    /// The location where the ball left the field (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The location where the ball was last touched (in meter).
+    pub kick_location: Option<Point2<f64>>,
+}
+
+/// Represents an event where an attacking robot is located too close to the opponent's defense area during a stoppage or free kick.
+#[derive(Clone, Debug)]
+pub struct AttackerTooCloseToDefenseArea {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that is too close to the defense area.
+    pub by_bot: Option<u32>,
+    /// The location of the bot (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The distance of the bot to the penalty area (in meter).
+    pub distance: Option<f64>,
+    /// The location of the ball at the moment when this foul occurred (in meter).
+    pub ball_location: Option<Point2<f64>>,
+}
+
+/// Represents an event where a defender other than the keeper was fully located inside its own defense and touched the ball.
+#[derive(Clone, Debug)]
+pub struct DefenderInDefenseArea {
+    /// The team that found guilty
+    pub by_team: TeamColor,
+    /// The bot that is inside the penalty area
+    pub by_bot: Option<u32>,
+    /// The location of the bot (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The distance from bot case to the nearest point outside the defense area (in meter).
+    pub distance: Option<f64>,
+}
+
+/// Represents an event where a robot chipped the ball over the field boundary out of the playing surface.
+#[derive(Clone, Debug)]
+pub struct BoundaryCrossing {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The location of the ball (in meter).
+    pub location: Option<Point2<f64>>,
+}
+
+/// Represents an event where a keeper held the ball in its defense area for too long.
+#[derive(Clone, Debug)]
+pub struct KeeperHeldBall {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The location of the ball (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The duration that the keeper hold the ball (in seconds).
+    pub duration: Option<Duration>,
+}
+
+/// Represents an event where a bot dribbled to ball too far.
+#[derive(Clone, Debug)]
+pub struct BotDribbledBallTooFar {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that dribbled too far.
+    pub by_bot: Option<u32>,
+    /// The location where the dribbling started (in meter).
+    pub start: Option<Point2<f64>>,
+    /// The location where the maximum dribbling distance was reached (in meter).
+    pub end: Option<Point2<f64>>,
+}
+
+/// Represents an event where a bot pushed another bot over a significant distance.
+#[derive(Clone, Debug)]
+pub struct BotPushedBot {
+    /// The team that pushed the other team.
+    pub by_team: TeamColor,
+    /// The bot that pushed the other bot.
+    pub violator: Option<u32>,
+    /// The bot of the opposite team that was pushed.
+    pub victim: Option<u32>,
+    /// The location of the push (center between both bots) (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The pushed distance (in meter).
+    pub pushed_distance: Option<f64>,
+}
+
+/// Represents an event where a bot held the ball for too long.
+#[derive(Clone, Debug)]
+pub struct BotHeldBallDeliberately {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that holds the ball.
+    pub by_bot: Option<u32>,
+    /// The location of the ball (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The duration that the bot hold the ball (in seconds).
+    pub duration: Option<Duration>,
+}
+
+/// Represents an event where a bot tipped over.
+#[derive(Clone, Debug)]
+pub struct BotTippedOver {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that tipped over.
+    pub by_bot: Option<u32>,
+    /// The location of the bot (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The location of the ball at the moment when this foul occurred (in meter).
+    pub ball_location: Option<Point2<f64>>,
+}
+
+/// Represents an event where an attacker touched the ball inside the opponent defense area.
+#[derive(Clone, Debug)]
+pub struct AttackerTouchedBallInDefenseArea {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that is inside the penalty area.
+    pub by_bot: Option<u32>,
+    /// The location of the bot (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The distance that the bot is inside the penalty area (in meter).
+    pub distance: Option<f64>,
+}
+
+/// Represents an event where a bot kicked the ball too fast.
+#[derive(Clone, Debug)]
+pub struct BotKickedBallTooFast {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that kicked too fast.
+    pub by_bot: Option<u32>,
+    /// The location of the ball at the time of the highest speed (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The absolute initial ball speed (kick speed) (in meter per second).
+    pub initial_ball_speed: Option<f64>,
+    /// Was the ball chipped?
+    pub chipped: Option<bool>,
+}
+
+/// Represents an event where two robots crashed into each other and one team was found guilty to due significant speed difference.
+#[derive(Clone, Debug)]
+pub struct BotCrashUnique {
+    /// The team that caused the crash.
+    pub by_team: TeamColor,
+    /// The bot that caused the crash.
+    pub violator: Option<u32>,
+    /// The bot of the opposite team that was involved in the crash.
+    pub victim: Option<u32>,
+    /// The location of the crash (center between both bots) (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The calculated crash speed vector of the two bots (in meter per second).
+    pub crash_speed: Option<f64>,
+    /// The difference of the velocity of the two bots (in meter per second).
+    pub speed_diff: Option<f64>,
+    /// the angle [rad] in the range [0, π] of the bot velocity vectors
+    /// an angle of 0 rad (  0°) means, the bots barely touched each other
+    /// an angle of π rad (180°) means, the bots crashed frontal into each other
+    pub crash_angle: Option<f64>,
+}
+/// Represents an event where two robots crashed into each other with similar speeds
+#[derive(Clone, Debug)]
+pub struct BotCrashDrawn {
+    /// The bot of the yellow team.
+    pub bot_yellow: Option<u32>,
+    /// The bot of the blue team.
+    pub bot_blue: Option<u32>,
+    /// The location of the crash (center between both bots) (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The calculated crash speed of the two bots (in meter per second).
+    pub crash_speed: Option<f64>,
+    /// The difference of the velocity of the two bots (in meter per second).
+    pub speed_diff: Option<f64>,
+    /// the angle [rad] in the range [0, π] of the bot velocity vectors
+    /// an angle of 0 rad (  0°) means, the bots barely touched each other
+    /// an angle of π rad (180°) means, the bots crashed frontal into each other.
+    pub crash_angle: Option<f64>,
+}
+
+/// Represents an event where a bot of the defending team got too close to the kick point during a free kick.
+#[derive(Clone, Debug)]
+pub struct DefenderTooCloseToKickPoint {
+    /// The team that was found guilty.
+    pub by_team: TeamColor,
+    /// The bot that violates the distance to the kick point.
+    pub by_bot: Option<u32>,
+    /// The location of the bot (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The distance from bot to the kick point (including the minimum radius) (in meter).
+    pub distance: Option<f64>,
+}
+
+/// Represents an event where a bot moved too fast while the game was stopped.
+#[derive(Clone, Debug)]
+pub struct BotTooFastInStop {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that was too fast.
+    pub by_bot: Option<u32>,
+    /// The location of the bot (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The bot speed (in meter per second).
+    pub speed: Option<f64>,
+}
+
+/// Represents an event where a bot interfered the ball placement of the other team.
+#[derive(Clone, Debug)]
+pub struct BotInterferedPlacement {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that interfered the placement.
+    pub by_bot: Option<u32>,
+    /// The location of the bot (in meter).
+    pub location: Option<Point2<f64>>,
+}
+
+/// Represents an event where a team shot a goal
+#[derive(Clone, Debug)]
+pub struct Goal {
+    /// The team that scored the goal.
+    pub by_team: TeamColor,
+    /// The team that shot the goal (different from by_team for own goals).
+    pub kicking_team: Option<TeamColor>,
+    /// The bot that shot the goal.
+    pub kicking_bot: Option<u32>,
+    /// The location where the ball entered the goal (in meter).
+    pub location: Option<Point2<f64>>,
+    /// The location where the ball was kicked (for deciding if this was a valid goal) (in meter).
+    pub kick_location: Option<Point2<f64>>,
+    /// The maximum height the ball reached during the goal kick (for deciding if this was a valid goal) (in meter).
+    pub max_ball_height: Option<f64>,
+    /// Number of robots of scoring team when the ball entered the goal (for deciding if this was a valid goal).
+    pub num_bots_by_team: Option<u32>,
+    /// The UNIX timestamp when the scoring team last touched the ball (in microsecond).
+    pub last_touch_by_team: Option<u64>,
+    /// An additional message with e.g. a reason for invalid goals.
+    pub message: Option<String>,
+}
+
+/// Represents an event where an attacker touched the ball multiple times when it was not allowed to.
+#[derive(Clone, Debug)]
+pub struct AttackerDoubleTouchedBall {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// The bot that touched the ball twice.
+    pub by_bot: Option<u32>,
+    /// The location of the ball when it was first touched (in meter).
+    pub location: Option<Point2<f64>>,
+}
+
+/// Represents an event where a team successfully placed the ball.
+#[derive(Clone, Debug)]
+pub struct PlacementSucceeded {
+    /// The team that did the placement.
+    pub by_team: TeamColor,
+    /// The time taken for placing the ball (in second).
+    pub time_taken: Option<f64>,
+    /// The distance between placement location and actual ball position (in meter).
+    pub precision: Option<f64>,
+    /// The distance between the initial ball location and the placement position (in meter).
+    pub distance: Option<f64>,
+}
+
+/// Represents an event where the penalty kick failed (by time or by keeper).
+#[derive(Clone, Debug)]
+pub struct PenaltyKickFailed {
+    /// The team that last touched the ball.
+    pub by_team: TeamColor,
+    /// The location of the ball at the moment of this event (in minute).
+    pub location: Option<Point2<f64>>,
+    /// An explanation of the failure.
+    pub reason: Option<String>,
+}
+
+/// Represents an event where game was stuck.
+#[derive(Clone, Debug)]
+pub struct NoProgressInGame {
+    /// The location of the ball.
+    pub location: Option<Point2<f64>>,
+    /// The time that was waited (in second).
+    pub time: Option<Duration>,
+}
+
+/// Represents an event where the ball placement failed.
+#[derive(Clone, Debug)]
+pub struct PlacementFailed {
+    /// The team that failed.
+    pub by_team: TeamColor,
+    /// The remaining distance from ball to placement position (in meter).
+    pub remaining_distance: Option<f64>,
+}
+
+/// Represents an event where a team collected multiple fouls, which results in a yellow card.
+#[derive(Clone, Debug)]
+pub struct MultipleFouls {
+    /// The team that collected multiple fouls.
+    pub by_team: TeamColor,
+    /// The list of game events that caused the multiple fouls.
+    pub caused_game_events: Vec<GameEvent>,
+}
+
+/// Represents an event where a team has too many robots on the field.
+#[derive(Clone, Debug)]
+pub struct TooManyRobots {
+    /// The team that has too many robots.
+    pub by_team: TeamColor,
+    /// Number of robots allowed at the moment.
+    pub num_robots_allowed: Option<u32>,
+    /// Number of robots currently on the field.
+    pub num_robots_on_field: Option<u32>,
+    /// The location of the ball at the moment when this foul occurred (in meter).
+    pub ball_location: Option<Point2<f64>>,
+}
+
+/// Represents an event where a team was found guilty for minor unsporting behavior.
+#[derive(Clone, Debug)]
+pub struct UnsportingBehaviorMinor {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// An explanation of the situation and decision.
+    pub reason: String,
+}
+
+/// Represents an event where a team was found guilty for minor unsporting behavior.
+#[derive(Clone, Debug)]
+pub struct UnsportingBehaviorMajor {
+    /// The team that found guilty.
+    pub by_team: TeamColor,
+    /// An explanation of the situation and decision.
+    pub reason: String,
+}
+
+/// Enum that represent the origin of the event.
+#[derive(Clone, Debug)]
+pub enum EventOrigin {
+    GameController,
+    Autorefs(Vec<String>),
+}

--- a/crates/crabe_filter/src/lib.rs
+++ b/crates/crabe_filter/src/lib.rs
@@ -21,6 +21,7 @@ use crabe_framework::config::CommonConfig;
 use crabe_framework::data::input::InboundData;
 use crabe_framework::data::world::{TeamColor, World};
 use crate::pre_filter::game_controller::GameControllerPreFilter;
+use crate::post_filter::game_controller::GameControllerPostFilter;
 
 #[derive(Args)]
 pub struct FilterConfig {}
@@ -44,7 +45,7 @@ impl FilterPipeline {
 
         if common_config.gc {
             pre_filters.push(Box::new(GameControllerPreFilter));
-            // post_filters.push(Box::)
+            post_filters.push(Box::new(GameControllerPostFilter::default()));
         }
 
         Self {

--- a/crates/crabe_filter/src/lib.rs
+++ b/crates/crabe_filter/src/lib.rs
@@ -20,6 +20,7 @@ use crabe_framework::component::{Component, FilterComponent};
 use crabe_framework::config::CommonConfig;
 use crabe_framework::data::input::InboundData;
 use crabe_framework::data::world::{TeamColor, World};
+use crate::pre_filter::game_controller::GameControllerPreFilter;
 
 #[derive(Args)]
 pub struct FilterConfig {}
@@ -34,23 +35,26 @@ pub struct FilterPipeline {
 
 impl FilterPipeline {
     pub fn with_config(_config: FilterConfig, common_config: &CommonConfig) -> Self {
+        let mut pre_filters: Vec<Box<dyn PreFilter>> = vec![Box::new(VisionFilter::new())];
+        let mut post_filters: Vec<Box<dyn PostFilter>> = vec![
+            Box::new(RobotFilter),
+            Box::new(GeometryFilter),
+            Box::new(BallFilter),
+        ];
+
+        if common_config.gc {
+            pre_filters.push(Box::new(GameControllerPreFilter));
+            // post_filters.push(Box::)
+        }
+
         Self {
-            pre_filters: vec![Box::new(VisionFilter::new())],
+            pre_filters,
             filters: vec![
                 Box::new(PassthroughFilter),
                 Box::<InactiveFilter>::default(),
             ],
-            post_filters: vec![
-                Box::new(RobotFilter),
-                Box::new(GeometryFilter),
-                Box::new(BallFilter),
-            ],
-            filter_data: FilterData {
-                allies: Default::default(),
-                enemies: Default::default(),
-                ball: Default::default(),
-                geometry: Default::default(),
-            },
+            post_filters,
+            filter_data: FilterData::default(),
             team_color: if common_config.yellow {
                 TeamColor::Yellow
             } else {
@@ -65,10 +69,10 @@ impl Component for FilterPipeline {
 }
 
 impl FilterComponent for FilterPipeline {
-    fn step(&mut self, inbound_data: InboundData, world: &mut World) {
+    fn step(&mut self, mut inbound_data: InboundData, world: &mut World) {
         self.pre_filters
             .iter_mut()
-            .for_each(|f| f.step(&inbound_data, &self.team_color, &mut self.filter_data));
+            .for_each(|f| f.step(&mut inbound_data, &self.team_color, &mut self.filter_data));
 
         self.filters
             .iter_mut()

--- a/crates/crabe_filter/src/post_filter.rs
+++ b/crates/crabe_filter/src/post_filter.rs
@@ -1,6 +1,7 @@
 pub mod ball;
 pub mod geometry;
 pub mod robot;
+pub mod game_controller;
 
 use crate::data::FilterData;
 use crabe_framework::data::world::World;

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -40,8 +40,6 @@ impl GameControllerPostFilter {
             self.state_data.prev_ref_cmd = self.state_data.last_ref_cmd;
         }
         self.state_data.last_ref_cmd = referee.command;
-        self.state_data.ally_score = referee.ally.score;
-        self.state_data.enemy_score = referee.enemy.score;
     }
 }
 
@@ -88,7 +86,6 @@ impl PostFilter for GameControllerPostFilter {
                 dbg!(&referee.command);
                 dbg!(referee.next_command);
 
-                self.update_team_scores(referee);
                 self.update_latest_state_data(referee);
 
                 new_state = self.resolve_branch(&referee.command)
@@ -99,6 +96,7 @@ impl PostFilter for GameControllerPostFilter {
 
                 dbg!(&new_state);
 
+                self.update_team_scores(referee);
                 world.data.ref_orders.update(new_state, referee.game_events.last());
             }
 

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -13,8 +13,6 @@ use crate::post_filter::PostFilter;
 /// Translates the received events and referee commands
 /// into specific game state for the game
 pub struct GameControllerPostFilter {
-    /// The previous different command from the referee (not the penultimate)
-    prev_command: RefereeCommand,
     /// Timer used for events that rely on specific durations.
     /// One example is the duration of the kickoff, during which
     /// if the opponent does not touch the ball after
@@ -26,11 +24,6 @@ pub struct GameControllerPostFilter {
 
 
 impl GameControllerPostFilter {
-    /// Checks whether the first kickoff already occurred,
-    /// and saves it in the current state data
-    fn save_if_first_kickoff_occurred(&mut self, prev_state: GameState) {
-        self.state_data.kicked_off_once = self.state_data.kicked_off_once || prev_state != GameState::Halted(HaltedState::GameNotStarted)
-    }
 
     /// Updates the team scores of both teams
     fn update_team_scores(&mut self, referee: &Referee) {
@@ -38,16 +31,20 @@ impl GameControllerPostFilter {
         self.state_data.enemy_score = referee.enemy.score;
     }
 
-    /// Saves the latest referee command
-    fn update_prev_ref_cmd(&mut self, current_ref_cmd: &RefereeCommand) {
-        self.prev_command = *current_ref_cmd;
+    /// Updates most fields concerning the latest valid state data
+    /// we've saved. The only field not modified by this function
+    /// is `kicked_off_once`. State branches are responsible for
+    /// updating this field instead
+    fn update_latest_state_data(&mut self, referee: &Referee) {
+        self.state_data.prev_ref_cmd = referee.command;
+        self.state_data.ally_score = referee.ally.score;
+        self.state_data.enemy_score = referee.enemy.score;
     }
 }
 
 impl Default for GameControllerPostFilter {
     fn default() -> Self {
         Self {
-            prev_command: RefereeCommand::Halt,
             timer: None,
             state_data: StateData::default(),
         }
@@ -84,22 +81,24 @@ impl PostFilter for GameControllerPostFilter {
 
             // change state only if a new referee command has been issued,
             // or a timer is currently being used
-            if self.prev_command != referee.command || self.timer != None {
+            if self.state_data.prev_ref_cmd != referee.command || self.timer != None {
                 dbg!(&referee.command);
                 // dbg!(&referee.game_events.last());
-                dbg!(&referee.designated_position);
-                dbg!(&referee.ally.score);
-                dbg!(&referee.enemy.score);
+                // dbg!(&referee.designated_position);
+                // dbg!(&referee.ally.score);
+                // dbg!(&referee.enemy.score);
 
+                // TODO: bug, don't updat prev ref command if we get here using self.timer != None branch
                 new_state = self.resolve_branch(&referee.command)
                     .process_state(world,
                                    referee,
                                    &mut self.timer,
-                                   &self.state_data);
+                                   &mut self.state_data);
 
-                self.save_if_first_kickoff_occurred(world.data.ref_orders.state);
+                dbg!(&new_state);
+
                 self.update_team_scores(referee);
-                self.update_prev_ref_cmd(&referee.command);
+                self.update_latest_state_data(referee);
                 world.data.ref_orders.update(new_state, referee.game_events.last());
             }
 

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -1,0 +1,118 @@
+use std::time::Instant;
+use crabe_framework::data::referee::referee_orders::RefereeOrders;
+use crabe_framework::data::referee::{Referee, RefereeCommand, TeamInfo};
+use crabe_framework::data::state_handler::game_state_handler::{ForceStartStateBranch, HaltStateBranch, DeprecatedStateBranch, NormalStartStateBranch, StopStateBranch};
+use crabe_framework::data::state_handler::{GameStateBranch, StateData};
+use crabe_framework::data::world::game_state::{GameState, HaltedState, RunningState};
+use crabe_framework::data::world::World;
+use crate::data::FilterData;
+use crate::post_filter::PostFilter;
+
+
+
+/// Translates the received events and referee commands
+/// into specific game state for the game
+pub struct GameControllerPostFilter {
+    /// The previous different command from the referee (not the penultimate)
+    prev_command: RefereeCommand,
+    /// Timer used for events that rely on specific durations.
+    /// One example is the duration of the kickoff, during which
+    /// if the opponent does not touch the ball after
+    timer: Option<Instant>,
+    /// Contains multiple information about the current state of the match
+    state_data: StateData,
+}
+
+
+
+impl GameControllerPostFilter {
+    /// Checks whether the first kickoff already occurred,
+    /// and saves it in the current state data
+    fn save_if_first_kickoff_occurred(&mut self, prev_state: GameState) {
+        self.state_data.kicked_off_once = self.state_data.kicked_off_once || prev_state != GameState::Halted(HaltedState::GameNotStarted)
+    }
+
+    /// Updates the team scores of both teams
+    fn update_team_scores(&mut self, referee: &Referee) {
+        self.state_data.ally_score = referee.ally.score;
+        self.state_data.enemy_score = referee.enemy.score;
+    }
+
+    /// Saves the latest referee command
+    fn update_prev_ref_cmd(&mut self, current_ref_cmd: &RefereeCommand) {
+        self.prev_command = *current_ref_cmd;
+    }
+}
+
+impl Default for GameControllerPostFilter {
+    fn default() -> Self {
+        Self {
+            prev_command: RefereeCommand::Halt,
+            timer: None,
+            state_data: StateData::default(),
+        }
+    }
+}
+
+impl GameControllerPostFilter {
+    fn resolve_branch(&self, referee_command: &RefereeCommand) -> impl GameStateBranch {
+        return HaltStateBranch;
+        // match referee_command {
+        //     RefereeCommand::Halt => HaltStateBranch,
+        //     RefereeCommand::Stop => StopStateBranch,
+        //     RefereeCommand::NormalStart => NormalStartStateBranch,
+        //     RefereeCommand::ForceStart => ForceStartStateBranch,
+        //     RefereeCommand::PrepareKickoff(_) => PrepareKickoffStateBranch
+        //     RefereeCommand::PreparePenalty(_) => PreparePenaltyStateBranch,
+        //     RefereeCommand::DirectFree(_) => DirectFreeStateBranch,
+        //     RefereeCommand::Timeout(_) => TimeoutStateBranch,
+        //     RefereeCommand::BallPlacement(_) => BallPlacementBranch
+        //
+        //     // Deprecated states (as per the protobuf files)
+        //     RefereeCommand::Goal(_) // Seems weird, but the protobuf file mentioned
+        //                             // we shouldn't base ourselves off this command
+        //                             // Tests show this is never sent
+        //     | RefereeCommand::IndirectFree(_)
+        //     | RefereeCommand::Deprecated => DeprecatedStateBranch
+        // }
+    }
+}
+
+impl PostFilter for GameControllerPostFilter {
+    fn step(&mut self, filter_data: &FilterData, world: &mut World) {
+        if let Some(referee) = filter_data.referee.last() {
+            let mut new_state = world.data.ref_orders.state;
+
+            // if let Some(time_remaining) = &referee.current_action_time_remaining {
+            //     if time_remaining.num_milliseconds() > 0 { dbg!(time_remaining); }
+            // }
+
+            // change state only if a new referee command has been issued,
+            // or a timer is currently being used
+            if self.prev_command != referee.command || self.timer != None {
+                dbg!(&referee.command);
+                // dbg!(&referee.game_events.last());
+                dbg!(&referee.designated_position);
+                dbg!(&referee.ally.score);
+                dbg!(&referee.enemy.score);
+
+                self.save_if_first_kickoff_occurred(world.data.ref_orders.state);
+                self.update_team_scores(referee);
+                self.update_prev_ref_cmd(&referee.command);
+                world.data.ref_orders.update(new_state, referee.game_events.last());
+            }
+
+            // update positive half, to see which team resides on the positive
+            // side of the field
+            if let Some(team_on_positive_half) = referee.positive_half {
+                world.data.positive_half = team_on_positive_half
+            }
+
+            // self.resolve_branch(&referee.command).process_state(world, referee, self.timer, self.prev_command);
+            // read referee command
+            // if new command != previous command or timer is used
+            //   => run associated branch
+            //   => update world.data.ref_orders
+        };
+    }
+}

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -84,7 +84,7 @@ impl PostFilter for GameControllerPostFilter {
             let mut new_state = world.data.ref_orders.state;
 
             // change state only if a new referee command has been issued,
-            // or a timer is currently being used
+            // or if the state is time-dependent
             if self.state_data.last_ref_cmd != referee.command || self.time_based_refresh {
                 dbg!(&referee.command);
                 dbg!(referee.next_command);
@@ -102,7 +102,7 @@ impl PostFilter for GameControllerPostFilter {
                 dbg!(&new_state);
 
                 self.update_team_scores(referee);
-                world.data.ref_orders.update(new_state, referee.game_events.last());
+                world.data.ref_orders.update(new_state, referee);
             }
 
             // update positive half, to see which team resides on the positive
@@ -111,11 +111,6 @@ impl PostFilter for GameControllerPostFilter {
                 world.data.positive_half = team_on_positive_half
             }
 
-            // self.resolve_branch(&referee.command).process_state(world, referee, self.timer, self.prev_command);
-            // read referee command
-            // if new command != previous command or timer is used
-            //   => run associated branch
-            //   => update world.data.ref_orders
         };
     }
 }

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -91,7 +91,6 @@ impl PostFilter for GameControllerPostFilter {
                 self.update_team_scores(referee);
                 self.update_latest_state_data(referee);
 
-                // TODO: bug, don't updat prev ref command if we get here using self.timer != None branch
                 new_state = self.resolve_branch(&referee.command)
                     .process_state(world,
                                    referee,

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -2,7 +2,7 @@ use std::time::Instant;
 use crabe_framework::data::referee::referee_orders::RefereeOrders;
 use crabe_framework::data::referee::{Referee, RefereeCommand, TeamInfo};
 use crabe_framework::data::state_handler::game_state_handler::{ForceStartStateBranch, HaltStateBranch, DeprecatedStateBranch, NormalStartStateBranch, StopStateBranch, PrepareKickoffStateBranch, PreparePenaltyStateBranch, FreekickStateBranch, TimeoutStateBranch, BallPlacementStateBranch};
-use crabe_framework::data::state_handler::{GameStateBranch, StateData};
+use crabe_framework::data::state_handler::{GameStateBranch, GameStateData};
 use crabe_framework::data::world::game_state::{GameState, HaltedState, RunningState};
 use crabe_framework::data::world::{TeamColor, World};
 use crate::data::FilterData;
@@ -17,7 +17,7 @@ pub struct GameControllerPostFilter {
     /// because it depends on a timer provided by the referee
     time_based_refresh: bool,
     /// Contains multiple information about the current state of the match
-    state_data: StateData,
+    state_data: GameStateData,
 }
 
 
@@ -50,7 +50,7 @@ impl Default for GameControllerPostFilter {
     fn default() -> Self {
         Self {
             time_based_refresh: false,
-            state_data: StateData::default(),
+            state_data: GameStateData::default(),
         }
     }
 }

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -40,6 +40,10 @@ impl GameControllerPostFilter {
             self.state_data.prev_ref_cmd = self.state_data.last_ref_cmd;
         }
         self.state_data.last_ref_cmd = referee.command;
+
+        if let Some(designated_pos) = referee.designated_position {
+            self.state_data.last_designated_pos = designated_pos / 1000.;
+        }
     }
 }
 
@@ -85,6 +89,7 @@ impl PostFilter for GameControllerPostFilter {
             if self.state_data.last_ref_cmd != referee.command || self.timer != None {
                 dbg!(&referee.command);
                 dbg!(referee.next_command);
+                dbg!(&referee.designated_position);
 
                 self.update_latest_state_data(referee);
 

--- a/crates/crabe_filter/src/pre_filter.rs
+++ b/crates/crabe_filter/src/pre_filter.rs
@@ -2,12 +2,35 @@ use crate::data::FilterData;
 use crabe_framework::data::input::InboundData;
 use crabe_framework::data::world::TeamColor;
 
+/// Filters vision data coming from
+/// the cameras, into structures of our own
 pub mod vision;
 
+/// Filters data from the game controller, who decides
+/// the current game state, fouls, half times and timeouts
+pub mod game_controller;
+
+/// Common functions used by both modules
+mod common;
+
+/// Responsible for converting incoming data
+/// from external sources (vision & game controller),
+/// stored in the field `inbound_data`,
+/// into data structures of our implementation
+/// that can be manipulated further, in the field `filter_data`.
+///
+/// Similar to an outlet adapter
+///
+/// Parameters :
+/// - inbound_data      Data received from external sources
+/// - team_color        The color of our own team
+/// - filter_data       Result of the processed incoming data
+//                      Must be modified when transforming
+//                      the incoming data
 pub trait PreFilter {
     fn step(
         &mut self,
-        inbound_data: &InboundData,
+        inbound_data: &mut InboundData,
         team_color: &TeamColor,
         filter_data: &mut FilterData,
     );

--- a/crates/crabe_filter/src/pre_filter/common.rs
+++ b/crates/crabe_filter/src/pre_filter/common.rs
@@ -1,0 +1,19 @@
+use chrono::{DateTime, LocalResult, TimeZone, Utc};
+use log::error;
+
+pub fn create_date_time(t_capture: i64) -> DateTime<Utc> {
+    //dbg!(t_capture);
+    match Utc.timestamp_opt(t_capture, 0) {
+        LocalResult::Single(dt) => dt,
+        LocalResult::None => {
+            let now_utc = Utc::now();
+            error!("Invalid timestamp, using current time: {}", now_utc);
+            now_utc
+        }
+        LocalResult::Ambiguous(dt_min, dt_max) => {
+            let dt_midpoint = dt_min + (dt_max - dt_min) / 2;
+            error!("Ambiguous timestamp resolved to midpoint: {}", dt_midpoint);
+            dt_midpoint
+        }
+    }
+}

--- a/crates/crabe_filter/src/pre_filter/game_controller.rs
+++ b/crates/crabe_filter/src/pre_filter/game_controller.rs
@@ -1,0 +1,517 @@
+use crate::data::FilterData;
+use crate::pre_filter::common::create_date_time;
+use crate::pre_filter::PreFilter;
+use chrono::Duration;
+use crabe_framework::data::input::InboundData;
+use crabe_framework::data::world::TeamColor;
+use crabe_protocol::protobuf::game_controller_packet;
+use nalgebra::Point2;
+
+use crabe_protocol::protobuf::game_controller_packet::game_event as protocol_event;
+use crabe_protocol::protobuf::game_controller_packet::game_event::{Event as ProtocolEventData, Goal as ProtocolGoal};
+
+use crabe_protocol::protobuf::game_controller_packet::{GameEvent as ProtocolEvent, game_event::Type as ProtocolType, MatchType as ProtocolMatchType, Referee as ProtocolReferee, Vector2 as ProtocolVector2};
+use crabe_protocol::protobuf::game_controller_packet::referee::{Command as ProtocolCommand, Command, Point as ProtocolPoint, Stage as ProtocolStage};
+use crate::data::referee::event::{Event, EventOrigin,AimlessKick, AttackerDoubleTouchedBall, AttackerTooCloseToDefenseArea, AttackerTouchedBallInDefenseArea, BallLeftField, BotCrashDrawn, BotCrashUnique, BotDribbledBallTooFar, BotHeldBallDeliberately, BotInterferedPlacement, BotKickedBallTooFast, BotPushedBot, BotTippedOver, BotTooFastInStop, BoundaryCrossing, DefenderInDefenseArea, DefenderTooCloseToKickPoint, GameEvent, Goal, KeeperHeldBall, MultipleFouls, NoProgressInGame, PenaltyKickFailed, PlacementFailed, PlacementSucceeded, TooManyRobots, UnsportingBehaviorMajor, UnsportingBehaviorMinor, GameEventType};
+
+use crate::data::referee::{GameEventProposalGroup, Referee, RefereeCommand, Stage, TeamInfo, MatchType};
+use crabe_protocol::protobuf::game_controller_packet::Team as ProtocolTeam;
+pub struct GameControllerPreFilter;
+
+impl GameControllerPreFilter {}
+
+fn to_team_infos(infos: game_controller_packet::referee::TeamInfo) -> TeamInfo {
+    let _infos = TeamInfo {
+        name: infos.name.into(),
+        score: infos.score,
+        red_cards: infos.red_cards,
+        yellow_card_times: infos.yellow_card_times.into(),
+        yellow_cards: infos.yellow_cards,
+        timeouts: infos.timeouts,
+        timeout_time: infos.timeout_time,
+        goalkeeper: infos.goalkeeper,
+        foul_counter: infos.foul_counter,
+        ball_placement_failures: infos.ball_placement_failures,
+        can_place_ball: infos.can_place_ball,
+        max_allowed_bots: infos.max_allowed_bots,
+        bot_substitution_intent: infos.bot_substitution_intent,
+        ball_placement_failures_reached: infos.ball_placement_failures_reached,
+        bot_substitution_allowed: infos.bot_substitution_allowed,
+    };
+    _infos
+}
+
+fn map_match_type(match_type: ProtocolMatchType) -> MatchType {
+    match match_type {
+        ProtocolMatchType::UnknownMatch => MatchType::UnknownMatch,
+        ProtocolMatchType::GroupPhase => MatchType::GroupPhase,
+        ProtocolMatchType::EliminationPhase => MatchType::EliminationPhase,
+        ProtocolMatchType::Friendly => MatchType::Friendly,
+    }
+}
+fn map_stage(stage: ProtocolStage) -> Stage {
+    match stage {
+        ProtocolStage::NormalFirstHalfPre => Stage::NormalFirstHalfPre,
+        ProtocolStage::NormalFirstHalf => Stage::NormalFirstHalf,
+        ProtocolStage::NormalHalfTime => Stage::NormalHalfTime,
+        ProtocolStage::NormalSecondHalfPre => Stage::NormalSecondHalfPre,
+        ProtocolStage::NormalSecondHalf => Stage::NormalSecondHalf,
+        ProtocolStage::ExtraTimeBreak => Stage::ExtraTimeBreak,
+        ProtocolStage::ExtraFirstHalfPre => Stage::ExtraFirstHalfPre,
+        ProtocolStage::ExtraFirstHalf => Stage::ExtraFirstHalf,
+        ProtocolStage::ExtraHalfTime => Stage::ExtraHalfTime,
+        ProtocolStage::ExtraSecondHalfPre => Stage::ExtraSecondHalfPre,
+        ProtocolStage::ExtraSecondHalf => Stage::ExtraSecondHalf,
+        ProtocolStage::PenaltyShootoutBreak => Stage::PenaltyShootoutBreak,
+        ProtocolStage::PenaltyShootout => Stage::PenaltyShootout,
+        ProtocolStage::PostGame => Stage::PostGame,
+    }
+}
+
+fn map_command(incoming: ProtocolCommand) -> RefereeCommand {
+    match incoming {
+        Command::Halt => RefereeCommand::Halt,
+        Command::Stop => RefereeCommand::Stop,
+        Command::NormalStart => RefereeCommand::NormalStart,
+        Command::ForceStart => RefereeCommand::ForceStart,
+        Command::PrepareKickoffYellow => RefereeCommand::PrepareKickoff(TeamColor::Yellow),
+        Command::PrepareKickoffBlue => RefereeCommand::PrepareKickoff(TeamColor::Blue),
+        Command::PreparePenaltyYellow => RefereeCommand::PreparePenalty(TeamColor::Yellow),
+        Command::PreparePenaltyBlue => RefereeCommand::PreparePenalty(TeamColor::Blue),
+        Command::DirectFreeYellow => RefereeCommand::DirectFree(TeamColor::Yellow),
+        Command::DirectFreeBlue => RefereeCommand::DirectFree(TeamColor::Blue),
+        Command::TimeoutYellow => RefereeCommand::Timeout(TeamColor::Yellow),
+        Command::TimeoutBlue => RefereeCommand::Timeout(TeamColor::Blue),
+        Command::BallPlacementYellow => RefereeCommand::BallPlacement(TeamColor::Yellow),
+        Command::BallPlacementBlue => RefereeCommand::BallPlacement(TeamColor::Blue),
+        Command::IndirectFreeYellow
+        | Command::IndirectFreeBlue
+        | Command::GoalYellow
+        | Command::GoalBlue => RefereeCommand::Deprecated,
+    }
+}
+
+fn map_team_color(team: ProtocolTeam) -> TeamColor {
+    match team {
+        ProtocolTeam::Blue | ProtocolTeam::Unknown => TeamColor::Blue, // TODO: Handle unknown?
+        ProtocolTeam::Yellow => TeamColor::Yellow
+    }
+}
+
+fn map_team_color_i32(value: i32) -> TeamColor {
+    map_team_color(ProtocolTeam::from_i32(value).unwrap_or(ProtocolTeam::Unknown))
+}
+
+fn map_point(point: ProtocolPoint) -> Point2<f64> {
+    Point2::new(point.x.into(), point.y.into())
+}
+
+fn map_vector_point(vector: ProtocolVector2) -> Point2<f64> {
+    Point2::new(vector.x.into(), vector.y.into())
+}
+
+fn map_goal(goal: ProtocolGoal) -> Goal {
+    Goal {
+        by_team: map_team_color_i32(goal.by_team),
+        kicking_team: goal.kicking_team.map(map_team_color_i32),
+        kicking_bot: goal.kicking_bot,
+        location: goal.location.map(map_vector_point),
+        kick_location: goal.kick_location.map(map_vector_point),
+        max_ball_height: goal.max_ball_height.map(|h| h as f64),
+        num_bots_by_team: goal.num_robots_by_team,
+        last_touch_by_team: goal.last_touch_by_team,
+        message: goal.message,
+    }
+}
+
+fn map_type(event_type: ProtocolType) -> GameEventType{
+    match event_type {
+        ProtocolType::BallLeftFieldTouchLine=>GameEventType::BallLeftFieldTouchLine,
+        ProtocolType::BallLeftFieldGoalLine=>GameEventType::BallLeftFieldGoalLine,
+        ProtocolType::AimlessKick=>GameEventType::AimlessKick,
+        ProtocolType::AttackerTooCloseToDefenseArea=>GameEventType::AttackerTooCloseToDefenseArea,
+        ProtocolType::DefenderInDefenseArea=>GameEventType::DefenderInDefenseArea,
+        ProtocolType::BoundaryCrossing=>GameEventType::BoundaryCrossing,
+        ProtocolType::KeeperHeldBall=>GameEventType::KeeperHeldBall,
+        ProtocolType::BotDribbledBallTooFar=>GameEventType::BotDribbledBallTooFar,
+        ProtocolType::BotPushedBot=>GameEventType::BotPushedBot,
+        ProtocolType::BotHeldBallDeliberately=>GameEventType::BotHeldBallDeliberately,
+        ProtocolType::BotTippedOver=>GameEventType::BotTippedOver,
+        ProtocolType::AttackerTouchedBallInDefenseArea=>GameEventType::AttackerTouchedBallInDefenseArea,
+        ProtocolType::BotKickedBallTooFast=>GameEventType::BotKickedBallTooFast,
+        ProtocolType::BotCrashUnique=>GameEventType::BotCrashUnique,
+        ProtocolType::BotCrashDrawn=>GameEventType::BotCrashDrawn,
+        ProtocolType::DefenderTooCloseToKickPoint=>GameEventType::DefenderTooCloseToKickPoint,
+        ProtocolType::BotTooFastInStop=>GameEventType::BotTooFastInStop,
+        ProtocolType::BotInterferedPlacement=>GameEventType::BotInterferedPlacement,
+        ProtocolType::PossibleGoal=>GameEventType::PossibleGoal,
+        ProtocolType::Goal=>GameEventType::Goal,
+        ProtocolType::InvalidGoal=>GameEventType::InvalidGoal,
+        ProtocolType::AttackerDoubleTouchedBall=>GameEventType::AttackerDoubleTouchedBall,
+        ProtocolType::PlacementSucceeded=>GameEventType::PlacementSucceeded,
+        ProtocolType::PenaltyKickFailed=>GameEventType::PenaltyKickFailed,
+        ProtocolType::NoProgressInGame=>GameEventType::NoProgressInGame,
+        ProtocolType::PlacementFailed=>GameEventType::PlacementFailed,
+        ProtocolType::MultipleCards=>GameEventType::MultipleCards,
+        ProtocolType::MultipleFouls=>GameEventType::MultipleFouls,
+        ProtocolType::BotSubstitution=>GameEventType::BotSubstitution,
+        ProtocolType::TooManyRobots=>GameEventType::TooManyRobots,
+        ProtocolType::ChallengeFlag=>GameEventType::ChallengeFlag,
+        ProtocolType::ChallengeFlagHandled=>GameEventType::ChallengeFlagHandled,
+        ProtocolType::EmergencyStop=>GameEventType::EmergencyStop,
+        ProtocolType::UnsportingBehaviorMinor=>GameEventType::UnsportingBehaviorMinor,
+        ProtocolType::UnsportingBehaviorMajor=>GameEventType::UnsportingBehaviorMajor,
+        ProtocolType::UnknownGameEventType => todo!(),
+        ProtocolType::Prepared => todo!(),
+        ProtocolType::IndirectGoal => todo!(),
+        ProtocolType::ChippedGoal => todo!(),
+        ProtocolType::KickTimeout => todo!(),
+        ProtocolType::AttackerTouchedOpponentInDefenseArea => todo!(),
+        ProtocolType::AttackerTouchedOpponentInDefenseAreaSkipped => todo!(),
+        ProtocolType::BotCrashUniqueSkipped => todo!(),
+        ProtocolType::BotPushedBotSkipped => todo!(),
+        ProtocolType::DefenderInDefenseAreaPartially => todo!(),
+        ProtocolType::MultiplePlacementFailures => todo!(),
+    }
+}
+
+fn map_ball_left_field(value: protocol_event::BallLeftField) -> BallLeftField {
+    BallLeftField {
+        by_team: map_team_color_i32(value.by_team),
+        by_bot: value.by_bot,
+        location: value.location.map(map_vector_point),
+    }
+}
+
+fn map_game_event(game_event: ProtocolEvent) -> Option<GameEvent> {
+    let created_timestamp = game_event.created_timestamp;
+    let event = game_event.event.map(map_event).flatten();
+    /* 
+    for ele in game_event.origin {
+        println!("{}",ele);
+    }
+    */
+    if let Some(event) = event {
+        Some(GameEvent{
+            type_event: match game_event.r#type{
+                Some(r#type) => ProtocolType::from_i32(r#type)
+                    .map(map_type),
+                None => None
+            },
+            created_timestamp,
+            event,
+            origin: Vec::from([EventOrigin::Autorefs(game_event.origin)])
+        })
+    }else{
+        None
+    }
+}
+
+fn map_event(event: ProtocolEventData) -> Option<Event> {
+    match event {
+            ProtocolEventData::BallLeftFieldTouchLine(data) => {
+                Some(Event::BallLeftFieldTouchLine(map_ball_left_field(data)))
+            }
+            ProtocolEventData::BallLeftFieldGoalLine(data) => {
+                Some(Event::BallLeftFieldTouchLine(map_ball_left_field(data)))
+            }
+            ProtocolEventData::AimlessKick(data) => {
+                Some(Event::AimlessKick(AimlessKick {
+                    by_team: map_team_color_i32(data.by_team),
+                    by_bot: data.by_bot,
+                    location: data.location.map(map_vector_point),
+                    kick_location: data.kick_location.map(map_vector_point),
+                }))
+            }
+            ProtocolEventData::AttackerTooCloseToDefenseArea(data) => {
+                Some(Event::AttackerTooCloseToDefenseArea(AttackerTooCloseToDefenseArea {
+                    by_team: map_team_color_i32(data.by_team),
+                    by_bot: data.by_bot,
+                    location: data.location.map(map_vector_point),
+                    distance: data.distance.map(|d| d as f64),
+                    ball_location: data.ball_location.map(map_vector_point),
+                }))
+            }
+            ProtocolEventData::DefenderInDefenseArea(data) => {
+                Some(Event::DefenderInDefenseArea(DefenderInDefenseArea {
+                    by_team: map_team_color_i32(data.by_team),
+                    by_bot: data.by_bot,
+                    location: data.location.map(map_vector_point),
+                    distance: data.distance.map(|d| d as f64),
+                }))
+            }
+            ProtocolEventData::BoundaryCrossing(data) => {
+                Some(Event::BoundaryCrossing(BoundaryCrossing {
+                    by_team: map_team_color_i32(data.by_team),
+                    location: data.location.map(map_vector_point),
+                }))
+            }
+            ProtocolEventData::KeeperHeldBall(data) => {
+                Some(Event::KeeperHeldBall(KeeperHeldBall {
+                    by_team: map_team_color_i32(data.by_team),
+                    location: data.location.map(map_vector_point),
+                    duration: data.duration.map(|d| Duration::seconds(d as i64)), // TODO: More precision?
+                }))
+            }
+            ProtocolEventData::BotDribbledBallTooFar(data) => {
+                Some(Event::BotDribbledBallTooFar(BotDribbledBallTooFar {
+                    by_team: map_team_color_i32(data.by_team),
+                    by_bot: data.by_bot,
+                    start: data.start.map(map_vector_point),
+                    end: data.end.map(map_vector_point),
+                }))
+            }
+            ProtocolEventData::BotPushedBot(data) => {
+                Some(Event::BotPushedBot(BotPushedBot {
+                    by_team: map_team_color_i32(data.by_team),
+                    violator: data.violator,
+                    victim: data.victim,
+                    location: data.location.map(map_vector_point),
+                    pushed_distance: data.pushed_distance.map(|d| d as f64),
+                }))
+            }
+            ProtocolEventData::BotHeldBallDeliberately(data) => {
+                Some(Event::BotHeldBallDeliberately(BotHeldBallDeliberately {
+                    by_team: map_team_color_i32(data.by_team),
+                    by_bot: data.by_bot,
+                    location: data.location.map(map_vector_point),
+                    duration: data.duration.map(|d| Duration::seconds(d as i64)), // TODO: More precision?
+                }))
+            }
+            ProtocolEventData::BotTippedOver(data) => {
+                Some(Event::BotTippedOver(BotTippedOver {
+                    by_team: map_team_color_i32(data.by_team),
+                    by_bot: data.by_bot,
+                    location: data.location.map(map_vector_point),
+                    ball_location: data.ball_location.map(map_vector_point),
+                }))
+            }
+            ProtocolEventData::AttackerTouchedBallInDefenseArea(data) => {
+                Some(Event::AttackerTouchedBallInDefenseArea(AttackerTouchedBallInDefenseArea {
+                    by_team: map_team_color_i32(data.by_team),
+                    by_bot: data.by_bot,
+                    location: data.location.map(map_vector_point),
+                    distance: data.distance.map(|d| d as f64),
+                }))
+            }
+            ProtocolEventData::BotKickedBallTooFast(data) => {
+                Some(Event::BotKickedBallTooFast(BotKickedBallTooFast {
+                    by_team: map_team_color_i32(data.by_team),
+                    by_bot: data.by_bot,
+                    location: data.location.map(map_vector_point),
+                    initial_ball_speed: data.initial_ball_speed.map(|s| s as f64),
+                    chipped: data.chipped,
+                }))
+            }
+            ProtocolEventData::BotCrashUnique(data) => {
+                Some(Event::BotCrashUnique(BotCrashUnique {
+                    by_team: map_team_color_i32(data.by_team),
+                    violator: data.violator,
+                    victim: data.victim,
+                    location: data.location.map(map_vector_point),
+                    crash_speed: data.crash_speed.map(|s| s as f64),
+                    speed_diff: data.speed_diff.map(|d| d as f64),
+                    crash_angle: data.crash_angle.map(|a| a as f64),
+                }))
+            }
+            ProtocolEventData::BotCrashDrawn(data) => {
+                Some(Event::BotCrashDrawn(BotCrashDrawn {
+                    bot_blue: data.bot_blue,
+                    bot_yellow: data.bot_yellow,
+                    crash_speed: data.crash_speed.map(|s| s as f64),
+                    speed_diff: data.speed_diff.map(|d| d as f64),
+                    crash_angle: data.crash_angle.map(|a| a as f64),
+                    location: None,
+                }))
+            }
+            ProtocolEventData::BotTooFastInStop(data) => {
+                Some(Event::BotTooFastInStop(BotTooFastInStop {
+                    by_team: map_team_color_i32(data.by_team),
+                    by_bot: data.by_bot,
+                    location: data.location.map(map_vector_point),
+                    speed: data.speed.map(|s| s as f64),
+                }))
+            }
+            ProtocolEventData::BotInterferedPlacement(data) => {
+                Some(Event::BotInterferedPlacement(BotInterferedPlacement {
+                    by_team: map_team_color_i32(data.by_team),
+                    by_bot: data.by_bot,
+                    location: data.location.map(map_vector_point),
+                }))
+            }
+            ProtocolEventData::PossibleGoal(data) => {
+                Some(Event::PossibleGoal(map_goal(data)))
+            }
+            ProtocolEventData::Goal(data) => {
+                Some(Event::Goal(map_goal(data)))
+            }
+            ProtocolEventData::InvalidGoal(data) => {
+                Some(Event::InvalidGoal(map_goal(data)))
+            }
+            ProtocolEventData::AttackerDoubleTouchedBall(data) => {
+                Some(Event::AttackerDoubleTouchedBall(AttackerDoubleTouchedBall {
+                    by_team: map_team_color_i32(data.by_team),
+                    by_bot: data.by_bot,
+                    location: data.location.map(map_vector_point),
+                }))
+            }
+            ProtocolEventData::PlacementSucceeded(data) => {
+                Some(Event::PlacementSucceeded(PlacementSucceeded {
+                    by_team: map_team_color_i32(data.by_team),
+                    time_taken: data.time_taken.map(|d| d as f64),
+                    precision: data.precision.map(|p| p as f64),
+                    distance: data.distance.map(|d| d as f64),
+                }))
+            }
+            ProtocolEventData::PlacementFailed(data) => {
+                Some(Event::PlacementFailed(PlacementFailed {
+                    by_team: map_team_color_i32(data.by_team),
+                    remaining_distance: data.remaining_distance.map(|d| d as f64),
+                }))
+            }
+            ProtocolEventData::PenaltyKickFailed(data) => {
+                Some(Event::PenaltyKickFailed(PenaltyKickFailed {
+                    by_team: map_team_color_i32(data.by_team),
+                    location: data.location.map(map_vector_point),
+                    reason: None,
+                }))
+            }
+            ProtocolEventData::NoProgressInGame(data) => {
+                Some(Event::NoProgressInGame(NoProgressInGame {
+                    location: data.location.map(map_vector_point),
+                    time: data.time.map(|d| Duration::seconds(d as i64)),
+                }))
+            }
+            ProtocolEventData::MultipleCards(data) => {
+                Some(Event::MultipleCards(map_team_color_i32(data.by_team)))
+            }
+            ProtocolEventData::MultipleFouls(data) => {
+                Some(Event::MultipleFouls(MultipleFouls {
+                    by_team: map_team_color_i32(data.by_team),
+                    caused_game_events: vec![], // TODO
+                }))
+            }
+            ProtocolEventData::BotSubstitution(data) => {
+                Some(Event::BotSubstitution(map_team_color_i32(data.by_team)))
+            }
+            ProtocolEventData::TooManyRobots(data) => {
+                Some(Event::TooManyRobots(TooManyRobots {
+                    by_team: map_team_color_i32(data.by_team),
+                    num_robots_allowed: data.num_robots_allowed.map(|n| if n < 0 { 0 } else { n as u32 }),
+                    num_robots_on_field: data.num_robots_on_field.map(|n| if n < 0 { 0 } else { n as u32 }),
+                    ball_location: data.ball_location.map(map_vector_point),
+                }))
+            }
+            ProtocolEventData::ChallengeFlag(data) => {
+                Some(Event::ChallengeFlag(map_team_color_i32(data.by_team)))
+            }
+            ProtocolEventData::EmergencyStop(data) => {
+                Some(Event::EmergencyStop(map_team_color_i32(data.by_team)))
+            }
+            ProtocolEventData::UnsportingBehaviorMinor(data) => {
+                Some(Event::UnsportingBehaviorMinor(UnsportingBehaviorMinor {
+                    by_team: map_team_color_i32(data.by_team),
+                    reason: data.reason,
+                }))
+            }
+            ProtocolEventData::UnsportingBehaviorMajor(data) => {
+                Some(Event::UnsportingBehaviorMajor(UnsportingBehaviorMajor {
+                    by_team: map_team_color_i32(data.by_team),
+                    reason: data.reason,
+                }))
+            }
+            ProtocolEventData::DefenderTooCloseToKickPoint(data) => {
+                Some(Event::DefenderTooCloseToKickPoint(DefenderTooCloseToKickPoint {
+                    by_team: map_team_color_i32(data.by_team),
+                    by_bot: data.by_bot,
+                    location: data.location.map(map_vector_point),
+                    distance: data.distance.map(|d| d as f64),
+                }))
+            }
+
+            // DEPRECATED
+            ProtocolEventData::Prepared(_) |
+            ProtocolEventData::IndirectGoal(_) |
+            ProtocolEventData::ChippedGoal(_) |
+            ProtocolEventData::KickTimeout(_) |
+            ProtocolEventData::AttackerTouchedOpponentInDefenseArea(_) |
+            ProtocolEventData::AttackerTouchedOpponentInDefenseAreaSkipped(_) |
+            ProtocolEventData::BotCrashUniqueSkipped(_) |
+            ProtocolEventData::BotPushedBotSkipped(_) |
+            ProtocolEventData::DefenderInDefenseAreaPartially(_) |
+            ProtocolEventData::ChallengeFlagHandled(_) |
+            ProtocolEventData::MultiplePlacementFailures(_) => {
+                None
+            }
+        }
+}
+
+struct RefereeDeserializationError;
+
+fn map_protobuf_referee(
+    mut packet: ProtocolReferee,
+    team_color: &TeamColor,
+) -> Result<Referee, RefereeDeserializationError> {
+    let (ally, enemy) = match team_color {
+        TeamColor::Yellow => (packet.yellow, packet.blue),
+        TeamColor::Blue => (packet.blue, packet.yellow),
+    };
+    Ok(Referee {
+        source_identifier: packet.source_identifier,
+        match_type: packet.match_type.map(|match_type|ProtocolMatchType::from_i32(match_type).map(map_match_type)).flatten(), // TODO: Handle error
+        packet_timestamp: create_date_time((packet.packet_timestamp / 1_000_000) as i64),
+        stage: ProtocolStage::from_i32(packet.stage)
+            .map(map_stage)
+            .ok_or(RefereeDeserializationError)?,
+        stage_time_left: packet
+            .stage_time_left
+            .map(|d| Duration::microseconds(d as i64)),
+        command: ProtocolCommand::from_i32(packet.command)
+            .map(map_command)
+            .ok_or(RefereeDeserializationError)?,
+        command_counter: packet.command_counter,
+        command_timestamp: create_date_time((packet.command_timestamp / 1_000_000) as i64),
+        ally: to_team_infos(ally),   // TODO : Rename and check
+        enemy: to_team_infos(enemy), // TODO : Rename and check
+        designated_position: packet.designated_position.map(map_point),
+        positive_half: packet.blue_team_on_positive_half.map(|b| {
+            if b {
+                TeamColor::Blue
+            } else {
+                TeamColor::Yellow
+            }
+        }),
+        next_command: packet
+            .next_command
+            .map(|c| ProtocolCommand::from_i32(c))
+            .flatten()
+            .map(map_command),
+        game_events: packet.game_events.drain(..).filter_map(map_game_event).collect(),
+        game_event_proposals: packet.game_event_proposals.drain(..).map(|mut p| GameEventProposalGroup {
+            game_event: p.game_event.drain(..).filter_map(map_game_event).collect(),
+            accepted: p.accepted,
+        }).collect(),
+        current_action_time_remaining: packet
+            .current_action_time_remaining
+            .map(|d| Duration::microseconds(d as i64)),
+    })
+    
+    // Ok(Referee {})
+}
+
+impl PreFilter for GameControllerPreFilter {
+    fn step(
+        &mut self,
+        inbound_data: &mut InboundData,
+        team_color: &TeamColor,
+        filter_data: &mut FilterData,
+    ) {
+        //println!("len: {}", inbound_data.gc_packet.len());
+        filter_data.referee.extend(
+            inbound_data
+                .gc_packet
+                .drain(..)
+                .filter_map(|packet| map_protobuf_referee(packet, team_color).ok()),
+        );
+    }
+}

--- a/crates/crabe_filter/src/pre_filter/game_controller.rs
+++ b/crates/crabe_filter/src/pre_filter/game_controller.rs
@@ -12,9 +12,9 @@ use crabe_protocol::protobuf::game_controller_packet::game_event::{Event as Prot
 
 use crabe_protocol::protobuf::game_controller_packet::{GameEvent as ProtocolEvent, game_event::Type as ProtocolType, MatchType as ProtocolMatchType, Referee as ProtocolReferee, Vector2 as ProtocolVector2};
 use crabe_protocol::protobuf::game_controller_packet::referee::{Command as ProtocolCommand, Command, Point as ProtocolPoint, Stage as ProtocolStage};
-use crate::data::referee::event::{Event, EventOrigin,AimlessKick, AttackerDoubleTouchedBall, AttackerTooCloseToDefenseArea, AttackerTouchedBallInDefenseArea, BallLeftField, BotCrashDrawn, BotCrashUnique, BotDribbledBallTooFar, BotHeldBallDeliberately, BotInterferedPlacement, BotKickedBallTooFast, BotPushedBot, BotTippedOver, BotTooFastInStop, BoundaryCrossing, DefenderInDefenseArea, DefenderTooCloseToKickPoint, GameEvent, Goal, KeeperHeldBall, MultipleFouls, NoProgressInGame, PenaltyKickFailed, PlacementFailed, PlacementSucceeded, TooManyRobots, UnsportingBehaviorMajor, UnsportingBehaviorMinor, GameEventType};
+use crabe_framework::data::referee::event::{Event, EventOrigin, AimlessKick, AttackerDoubleTouchedBall, AttackerTooCloseToDefenseArea, AttackerTouchedBallInDefenseArea, BallLeftField, BotCrashDrawn, BotCrashUnique, BotDribbledBallTooFar, BotHeldBallDeliberately, BotInterferedPlacement, BotKickedBallTooFast, BotPushedBot, BotTippedOver, BotTooFastInStop, BoundaryCrossing, DefenderInDefenseArea, DefenderTooCloseToKickPoint, GameEvent, Goal, KeeperHeldBall, MultipleFouls, NoProgressInGame, PenaltyKickFailed, PlacementFailed, PlacementSucceeded, TooManyRobots, UnsportingBehaviorMajor, UnsportingBehaviorMinor, GameEventType};
 
-use crate::data::referee::{GameEventProposalGroup, Referee, RefereeCommand, Stage, TeamInfo, MatchType};
+use crabe_framework::data::referee::{GameEventProposalGroup, Referee, RefereeCommand, Stage, TeamInfo, MatchType};
 use crabe_protocol::protobuf::game_controller_packet::Team as ProtocolTeam;
 pub struct GameControllerPreFilter;
 

--- a/crates/crabe_filter/src/pre_filter/game_controller.rs
+++ b/crates/crabe_filter/src/pre_filter/game_controller.rs
@@ -213,7 +213,7 @@ fn map_event(event: ProtocolEventData) -> Option<Event> {
                 Some(Event::BallLeftFieldTouchLine(map_ball_left_field(data)))
             }
             ProtocolEventData::BallLeftFieldGoalLine(data) => {
-                Some(Event::BallLeftFieldTouchLine(map_ball_left_field(data)))
+                Some(Event::BallLeftFieldGoalLine(map_ball_left_field(data)))
             }
             ProtocolEventData::AimlessKick(data) => {
                 Some(Event::AimlessKick(AimlessKick {

--- a/crates/crabe_filter/src/pre_filter/vision.rs
+++ b/crates/crabe_filter/src/pre_filter/vision.rs
@@ -6,10 +6,10 @@ use crabe_framework::data::world::TeamColor;
 
 mod detection {
     use crate::data::{FilterData, FrameInfo};
-    use chrono::{DateTime, LocalResult, TimeZone, Utc};
+    use chrono::{TimeZone, Utc};
     use crabe_framework::data::world::TeamColor;
     use crabe_protocol::protobuf::vision_packet::SslDetectionFrame;
-    use log::error;
+    use crate::pre_filter::common::create_date_time;
 
     mod robot {
         use crate::data::{camera::CamRobot, FrameInfo, TrackedRobot, TrackedRobotMap};
@@ -114,22 +114,6 @@ mod detection {
         }
     }
 
-    fn create_date_time(t_capture: f64) -> DateTime<Utc> {
-        match Utc.timestamp_opt((t_capture) as i64, 0) {
-            LocalResult::Single(dt) => dt,
-            LocalResult::None => {
-                let now_utc = Utc::now();
-                error!("Invalid timestamp, using current time: {}", now_utc);
-                now_utc
-            }
-            LocalResult::Ambiguous(dt_min, dt_max) => {
-                let dt_midpoint = dt_min + (dt_max - dt_min) / 2;
-                error!("Ambiguous timestamp resolved to midpoint: {}", dt_midpoint);
-                dt_midpoint
-            }
-        }
-    }
-
     pub fn handle_detection(
         detection: &SslDetectionFrame,
         filter_data: &mut FilterData,
@@ -138,7 +122,7 @@ mod detection {
         let frame_info = FrameInfo {
             camera_id: detection.camera_id,
             frame_number: detection.frame_number,
-            t_capture: create_date_time(Utc::now().timestamp() as f64),
+            t_capture: create_date_time(Utc::now().timestamp()),
         };
 
         let mut robot_detection_info = robot::RobotDetectionInfo {
@@ -239,7 +223,7 @@ impl VisionFilter {
 impl PreFilter for VisionFilter {
     fn step(
         &mut self,
-        inbound_data: &InboundData,
+        inbound_data: &mut InboundData,
         team_color: &TeamColor,
         filter_data: &mut FilterData,
     ) {

--- a/crates/crabe_framework/Cargo.toml
+++ b/crates/crabe_framework/Cargo.toml
@@ -15,3 +15,4 @@ crabe_protocol = { path = "../crabe_protocol" }
 crabe_math = { path = "../crabe_math" }
 chrono={ version="0.4.31", features = ["serde"]}
 serde_with = "3.4.0"
+log = "0.4.21"

--- a/crates/crabe_framework/src/config.rs
+++ b/crates/crabe_framework/src/config.rs
@@ -9,4 +9,8 @@ pub struct CommonConfig {
     /// Whether robots are operating in the real world or in simulation.
     #[arg(short, long)]
     pub real: bool,
+    /// Specifies whether we should receive data
+    /// from the external Game Controller of the Robocup SSL.
+    #[arg(long)]
+    pub gc: bool,
 }

--- a/crates/crabe_framework/src/data.rs
+++ b/crates/crabe_framework/src/data.rs
@@ -16,3 +16,7 @@ pub mod tool;
 pub mod world;
 /// The referee module contains the different orders issued by a referee
 pub mod referee;
+/// The state_handler module contains the definition of the internal
+/// state machine that we use to process the current state of the game,
+/// based on the commands sent by the referee
+pub mod state_handler;

--- a/crates/crabe_framework/src/data.rs
+++ b/crates/crabe_framework/src/data.rs
@@ -14,3 +14,5 @@ pub mod tool;
 /// The world module contains the data structures for representing the state of the world
 /// in the control system. It includes information about robots, the ball, and the field.
 pub mod world;
+/// The referee module contains the different orders issued by a referee
+pub mod referee;

--- a/crates/crabe_framework/src/data/referee.rs
+++ b/crates/crabe_framework/src/data/referee.rs
@@ -1,9 +1,10 @@
 use chrono::{DateTime, Duration, Utc};
-use crabe_framework::data::world::TeamColor;
+use crate::data::world::TeamColor;
 use event::GameEvent;
 use nalgebra::Point2;
 
 pub mod event;
+pub mod referee_orders;
 
 /// MatchType is a meta information about the current match for easier log processing.
 #[derive(

--- a/crates/crabe_framework/src/data/referee.rs
+++ b/crates/crabe_framework/src/data/referee.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Duration, Utc};
 use crate::data::world::TeamColor;
 use event::GameEvent;
 use nalgebra::Point2;
+use crate::data::referee::referee_orders::RefereeOrders;
 
 pub mod event;
 pub mod referee_orders;
@@ -54,7 +55,7 @@ pub struct Referee {
     pub enemy: TeamInfo,
     /// The coordinates of the designated Position (in millimeters).
     /// Use only in the case of a ball placement command.
-    pub designated_position: Option<Point2<f64>>,
+    pub designated_position: Option<Point2<f64>>, // TODO: send that to the viewer
     /// Information about the direction of play.
     /// True, if the blue team will have it's goal on the positive x-axis of the ssl-vision coordinate system.
     /// Obviously, the yellow team will play on the opposite half.
@@ -119,7 +120,7 @@ pub enum Stage {
 
 /// The `RefereeCommand` enum represents a set of possible commands that a referee can issue during a game.
 /// These commands control the state of the game and dictate the actions that robots are allowed to perform at any given moment.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Copy, Hash)]
 pub enum RefereeCommand {
     /// Command indicating that all robots must halt movement immediately.
     Halt,

--- a/crates/crabe_framework/src/data/referee/event.rs
+++ b/crates/crabe_framework/src/data/referee/event.rs
@@ -162,7 +162,7 @@ pub enum Event {
     BotHeldBallDeliberately(BotHeldBallDeliberately),
     BotTippedOver(BotTippedOver),
 
-    // Non-Stopping Fouls
+    //  Non-Stopping Fouls
     AttackerTouchedBallInDefenseArea(AttackerTouchedBallInDefenseArea),
     BotKickedBallTooFast(BotKickedBallTooFast),
     BotCrashUnique(BotCrashUnique),
@@ -213,7 +213,7 @@ pub struct BallLeftField {
 }
 
 /// Represents an event where the ball left the field via goal line and a team committed an aimless kick.
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Clone, Debug, Copy)]
 pub struct AimlessKick {
     /// The team that last touched the ball
     pub by_team: TeamColor,

--- a/crates/crabe_framework/src/data/referee/referee_orders.rs
+++ b/crates/crabe_framework/src/data/referee/referee_orders.rs
@@ -72,7 +72,13 @@ impl RefereeOrders {
         self.state = game_state;
         self.speed_limit = Self::get_speed_limit_during(game_state);
         self.min_dist_from_ball = Self::get_min_dist_from_ball_during(game_state);
-        self.event = *referee.game_events.last();
+        // dev note : this one is a bit weird
+        // it's either this or putting lifetimes onto structs (notably on the `World` struct)
+        self.event = match referee.game_events.last() {
+            None => None,
+            Some(ge_ref) => { Some(ge_ref.clone()) }
+        };
+
         self.designated_position = referee.designated_position;
     }
 }

--- a/crates/crabe_framework/src/data/referee/referee_orders.rs
+++ b/crates/crabe_framework/src/data/referee/referee_orders.rs
@@ -8,12 +8,16 @@ use crate::data::world::game_state::{GameState, HaltedState};
 #[derive(Serialize, Clone, Debug)]
 pub struct RefereeOrders {
     /// Current game state
-    state: GameState,
+    pub state: GameState,
     /// Latest event that occurred on the field
-    event: Option<GameEvent>,
+    pub event: Option<GameEvent>,
     /// Maximum speed limit authorized for all robots
     /// Unit is in meters per second (m/s)
-    speed_limit: f32,
+    pub speed_limit: f32,
+    /// Minimum distance to stay away from the ball
+    /// There might not be any distance required, for example
+    /// during a normal running state
+    pub min_dist_from_ball: Option<f32>,
 }
 
 const MAX_SPEED_HALTED: f32 = 0.;
@@ -21,7 +25,6 @@ const MAX_SPEED_STOPPED: f32 = 1.5;
 //TODO: use MAX_LINEAR constant ? (can't because of circular dependency
 // between crabe_framework and crabe_guard)
 const MAX_SPEED_RUNNING: f32 = 6.; // Arbitrary value, not defined by the rulebook
-
 
 impl RefereeOrders {
     /// Get the maximum speed authorized during a given game state
@@ -35,6 +38,16 @@ impl RefereeOrders {
             GameState::Running(_) => MAX_SPEED_RUNNING,
         }
     }
+    
+    /// Get the minimum distance our robots have to stay away
+    /// from the ball during a given state
+    pub fn get_min_dist_from_ball_during(game_state: GameState) -> Option<f32> {
+        match game_state {
+            GameState::Halted(_) => None,
+            GameState::Stopped(_) => Some(1.5),
+            GameState::Running(_) => None,
+        }
+    }
 
     /// Creates a new instance, that defines the speed limits
     /// depending on the current game state provided
@@ -43,7 +56,22 @@ impl RefereeOrders {
             state: game_state,
             event: game_event,
             speed_limit: Self::get_speed_limit_during(game_state),
+            min_dist_from_ball: None,
         }
+    }
+
+    /// Updates the struct with the new information provided
+    /// Convenience function to avoid having to create/drop similar objects
+    pub fn update(&mut self, game_state: GameState, game_event: Option<&GameEvent>) {
+        self.state = game_state;
+        self.speed_limit = Self::get_speed_limit_during(game_state);
+
+        // dev note : this one is a bit weird
+        // it's either this or putting lifetimes onto structs (notably on the `World` struct)
+        self.event = match game_event {
+            None => None,
+            Some(ge_ref) => { Some(ge_ref.clone()) }
+        };
     }
 }
 
@@ -52,7 +80,8 @@ impl Default for RefereeOrders {
         Self {
             state: GameState::Halted(HaltedState::GameNotStarted),
             event: None,
-            speed_limit: 0.0,
+            speed_limit: MAX_SPEED_HALTED,
+            min_dist_from_ball: None,
         }
     }
 }

--- a/crates/crabe_framework/src/data/referee/referee_orders.rs
+++ b/crates/crabe_framework/src/data/referee/referee_orders.rs
@@ -1,0 +1,58 @@
+use serde::Serialize;
+use crate::data::referee::event::GameEvent;
+use crate::data::world::game_state::{GameState, HaltedState};
+
+/// Retains information sent by the game controller
+/// to both teams, about the current game state,
+/// the maximum speed allowed
+#[derive(Serialize, Clone, Debug)]
+pub struct RefereeOrders {
+    /// Current game state
+    state: GameState,
+    /// Latest event that occurred on the field
+    event: Option<GameEvent>,
+    /// Maximum speed limit authorized for all robots
+    /// Unit is in meters per second (m/s)
+    speed_limit: f32,
+}
+
+const MAX_SPEED_HALTED: f32 = 0.;
+const MAX_SPEED_STOPPED: f32 = 1.5;
+//TODO: use MAX_LINEAR constant ? (can't because of circular dependency
+// between crabe_framework and crabe_guard)
+const MAX_SPEED_RUNNING: f32 = 6.; // Arbitrary value, not defined by the rulebook
+
+
+impl RefereeOrders {
+    /// Get the maximum speed authorized during a given game state
+    /// There are no specific speed limits for certain events,
+    /// such as a penalty.
+    /// Speed limits are only defined for three main types of game states
+    pub fn get_speed_limit_during(game_state: GameState) -> f32 {
+        match game_state {
+            GameState::Halted(_) => MAX_SPEED_HALTED,
+            GameState::Stopped(_) => MAX_SPEED_STOPPED,
+            GameState::Running(_) => MAX_SPEED_RUNNING,
+        }
+    }
+
+    /// Creates a new instance, that defines the speed limits
+    /// depending on the current game state provided
+    pub fn new(game_state: GameState, game_event: Option<GameEvent>) -> Self {
+        Self {
+            state: game_state,
+            event: game_event,
+            speed_limit: Self::get_speed_limit_during(game_state),
+        }
+    }
+}
+
+impl Default for RefereeOrders {
+    fn default() -> Self {
+        Self {
+            state: GameState::Halted(HaltedState::GameNotStarted),
+            event: None,
+            speed_limit: 0.0,
+        }
+    }
+}

--- a/crates/crabe_framework/src/data/referee/referee_orders.rs
+++ b/crates/crabe_framework/src/data/referee/referee_orders.rs
@@ -65,6 +65,7 @@ impl RefereeOrders {
     pub fn update(&mut self, game_state: GameState, game_event: Option<&GameEvent>) {
         self.state = game_state;
         self.speed_limit = Self::get_speed_limit_during(game_state);
+        self.min_dist_from_ball = Self::get_min_dist_from_ball_during(game_state);
 
         // dev note : this one is a bit weird
         // it's either this or putting lifetimes onto structs (notably on the `World` struct)

--- a/crates/crabe_framework/src/data/state_handler.rs
+++ b/crates/crabe_framework/src/data/state_handler.rs
@@ -38,14 +38,14 @@ pub trait GameStateBranch {
                      world: &World,
                      referee: &Referee,
                      time_based_refresh: &mut bool,
-                     previous_state_data: &mut StateData) -> GameState;
+                     previous_state_data: &mut GameStateData) -> GameState;
 }
 
 /// This struct contains the strict minimum required
 /// to help us determine what will be the next valid
 /// state of the match, depending on the commands issued
 /// from the referee
-pub struct StateData {
+pub struct GameStateData {
     /// Whether the first kickoff already occurred or not
     pub kicked_off_once: bool,
     /// The previous referee command, different from the current one
@@ -60,7 +60,7 @@ pub struct StateData {
     pub enemy_score: u32,
 }
 
-impl Default for StateData {
+impl Default for GameStateData {
     fn default() -> Self {
         Self {
             kicked_off_once: false,

--- a/crates/crabe_framework/src/data/state_handler.rs
+++ b/crates/crabe_framework/src/data/state_handler.rs
@@ -23,7 +23,9 @@ pub trait GameStateBranch {
     /// Parameters :
     /// - `world`                     | Information on the world
     /// - `referee`                   | The current data issued from the referee
-    /// - `timer`                     | Used for specific events. Set to None if it is not in use
+    /// - `time_based_refresh`        | Set to true if we need to refresh the state constantly
+    ///                                 (for example, a free kick state is time based, we need to update
+    ///                                 the state again to check if we switch to another state or not)
     /// - `previous_state_data`       | Stores information about the latest
     ///                                 valid state we encountered. It is a capture
     ///                                 of the *previous* state. Responsible to modify
@@ -35,7 +37,7 @@ pub trait GameStateBranch {
     fn process_state(&self,
                      world: &World,
                      referee: &Referee,
-                     timer_opt: &mut Option<Instant>,
+                     time_based_refresh: &mut bool,
                      previous_state_data: &mut StateData) -> GameState;
 }
 

--- a/crates/crabe_framework/src/data/state_handler.rs
+++ b/crates/crabe_framework/src/data/state_handler.rs
@@ -47,6 +47,8 @@ pub struct StateData {
     pub kicked_off_once: bool,
     /// The previous referee command, different from the current one
     pub prev_ref_cmd: RefereeCommand,
+    /// The most recent referee command issued
+    pub last_ref_cmd: RefereeCommand,
     /// Last saved score of the ally team
     pub ally_score: u32,
     /// Last saved score of the enemy team
@@ -58,6 +60,7 @@ impl Default for StateData {
         Self {
             kicked_off_once: false,
             prev_ref_cmd: RefereeCommand::Halt,
+            last_ref_cmd: RefereeCommand::Halt,
             ally_score: 0,
             enemy_score: 0,
         }

--- a/crates/crabe_framework/src/data/state_handler.rs
+++ b/crates/crabe_framework/src/data/state_handler.rs
@@ -24,8 +24,8 @@ pub trait GameStateBranch {
     /// - `referee`                   | The current data issued from the referee
     /// - `timer`                     | Used for specific events. Set to None if it is not in use
     /// - `for_team`                  | The team concerned for the referee command
-    ///                             | If the blue team is doing a kickoff,
-    ///                             | `for_team` will be set to TeamColor::Blue
+    ///                               | If the blue team is doing a kickoff,
+    ///                               | `for_team` will be set to TeamColor::Blue
     /// - `previous_state_data`       | Stores information about the latest
     ///                             valid state we encountered. It is a capture
     ///                             of the *previous* state
@@ -36,7 +36,7 @@ pub trait GameStateBranch {
                      world: &World,
                      referee: &Referee,
                      timer_opt: &mut Option<Instant>,
-                     for_team: &TeamColor,
+                     for_team: Option<TeamColor>,
                      previous_state_data: &StateData) -> GameState;
 }
 

--- a/crates/crabe_framework/src/data/state_handler.rs
+++ b/crates/crabe_framework/src/data/state_handler.rs
@@ -1,6 +1,7 @@
 pub mod game_state_handler;
 
 use std::time::Instant;
+use nalgebra::Point2;
 use crate::data::referee::{Referee, RefereeCommand};
 use crate::data::world::game_state::{GameState, HaltedState};
 use crate::data::world::{TeamColor, World};
@@ -49,6 +50,8 @@ pub struct StateData {
     pub prev_ref_cmd: RefereeCommand,
     /// The most recent referee command issued
     pub last_ref_cmd: RefereeCommand,
+    /// Latest designated position provided by the referee
+    pub last_designated_pos: Point2<f64>,
     /// Last saved score of the ally team
     pub ally_score: u32,
     /// Last saved score of the enemy team
@@ -61,6 +64,7 @@ impl Default for StateData {
             kicked_off_once: false,
             prev_ref_cmd: RefereeCommand::Halt,
             last_ref_cmd: RefereeCommand::Halt,
+            last_designated_pos: Point2::new(0., 0.),
             ally_score: 0,
             enemy_score: 0,
         }

--- a/crates/crabe_framework/src/data/state_handler.rs
+++ b/crates/crabe_framework/src/data/state_handler.rs
@@ -23,20 +23,16 @@ pub trait GameStateBranch {
     /// - `world`                     | Information on the world
     /// - `referee`                   | The current data issued from the referee
     /// - `timer`                     | Used for specific events. Set to None if it is not in use
-    /// - `for_team`                  | The team concerned for the referee command
-    ///                               | If the blue team is doing a kickoff,
-    ///                               | `for_team` will be set to TeamColor::Blue
     /// - `previous_state_data`       | Stores information about the latest
     ///                             valid state we encountered. It is a capture
     ///                             of the *previous* state
     ///
     /// Returns
     /// - The game state in which we are in
-    fn process_state(&mut self,
+    fn process_state(&self,
                      world: &World,
                      referee: &Referee,
                      timer_opt: &mut Option<Instant>,
-                     for_team: Option<TeamColor>,
                      previous_state_data: &StateData) -> GameState;
 }
 

--- a/crates/crabe_framework/src/data/state_handler.rs
+++ b/crates/crabe_framework/src/data/state_handler.rs
@@ -1,0 +1,67 @@
+pub mod game_state_handler;
+
+use std::time::Instant;
+use crate::data::referee::{Referee, RefereeCommand};
+use crate::data::world::game_state::GameState;
+use crate::data::world::{TeamColor, World};
+
+/// This trait defines how each game state should be handled
+/// for each possible game state that can be issued by the
+/// referee. Because the commands issued by the referee are limited,
+/// it is up to us to determine what state we are playing in.
+/// This is the grey part of the game, where you have to understand
+/// what's happening as per the rulebook.
+pub trait GameStateBranch {
+    /// Process a single referee command, that changes the state
+    /// of the game, and returns the new state of the match
+    ///
+    /// Thus, to determine the state we are currently in,
+    /// you can access the data issued by the referee,
+    /// and the data of the previous state we were in
+    ///
+    /// Parameters :
+    /// - `world`                     | Information on the world
+    /// - `referee`                   | The current data issued from the referee
+    /// - `timer`                     | Used for specific events. Set to None if it is not in use
+    /// - `for_team`                  | The team concerned for the referee command
+    ///                             | If the blue team is doing a kickoff,
+    ///                             | `for_team` will be set to TeamColor::Blue
+    /// - `previous_state_data`       | Stores information about the latest
+    ///                             valid state we encountered. It is a capture
+    ///                             of the *previous* state
+    ///
+    /// Returns
+    /// - The game state in which we are in
+    fn process_state(&mut self,
+                     world: &World,
+                     referee: &Referee,
+                     timer_opt: &mut Option<Instant>,
+                     for_team: &TeamColor,
+                     previous_state_data: &StateData) -> GameState;
+}
+
+/// This struct contains the strict minimum required
+/// to help us determine what will be the next valid
+/// state of the match, depending on the commands issued
+/// from the referee
+pub struct StateData {
+    /// Whether the first kickoff already occurred or not
+    pub kicked_off_once: bool,
+    /// The previous referee command, different from the current one
+    pub prev_ref_cmd: RefereeCommand,
+    /// Last saved score of the ally team
+    pub ally_score: u32,
+    /// Last saved score of the enemy team
+    pub enemy_score: u32,
+}
+
+impl Default for StateData {
+    fn default() -> Self {
+        Self {
+            kicked_off_once: false,
+            prev_ref_cmd: RefereeCommand::Halt,
+            ally_score: 0,
+            enemy_score: 0,
+        }
+    }
+}

--- a/crates/crabe_framework/src/data/state_handler.rs
+++ b/crates/crabe_framework/src/data/state_handler.rs
@@ -2,7 +2,7 @@ pub mod game_state_handler;
 
 use std::time::Instant;
 use crate::data::referee::{Referee, RefereeCommand};
-use crate::data::world::game_state::GameState;
+use crate::data::world::game_state::{GameState, HaltedState};
 use crate::data::world::{TeamColor, World};
 
 /// This trait defines how each game state should be handled
@@ -24,8 +24,10 @@ pub trait GameStateBranch {
     /// - `referee`                   | The current data issued from the referee
     /// - `timer`                     | Used for specific events. Set to None if it is not in use
     /// - `previous_state_data`       | Stores information about the latest
-    ///                             valid state we encountered. It is a capture
-    ///                             of the *previous* state
+    ///                                 valid state we encountered. It is a capture
+    ///                                 of the *previous* state. Responsible to modify
+    ///                                 this with updated state data, if required (used to remember
+    ///                                 if first kickoff occurred)
     ///
     /// Returns
     /// - The game state in which we are in
@@ -33,7 +35,7 @@ pub trait GameStateBranch {
                      world: &World,
                      referee: &Referee,
                      timer_opt: &mut Option<Instant>,
-                     previous_state_data: &StateData) -> GameState;
+                     previous_state_data: &mut StateData) -> GameState;
 }
 
 /// This struct contains the strict minimum required

--- a/crates/crabe_framework/src/data/state_handler/game_state_handler.rs
+++ b/crates/crabe_framework/src/data/state_handler/game_state_handler.rs
@@ -41,8 +41,10 @@ impl GameStateBranch for HaltStateBranch {
     fn process_state(&self,
                      _world: &World,
                      _referee: &Referee,
-                     _timer_opt: &mut Option<Instant>,
+                     timer_opt: &mut Option<Instant>,
                      _latest_data: &mut StateData) -> GameState {
+        // reset timer
+        *timer_opt = None;
         return GameState::Halted(HaltedState::Halt);
     }
 }

--- a/crates/crabe_framework/src/data/state_handler/game_state_handler.rs
+++ b/crates/crabe_framework/src/data/state_handler/game_state_handler.rs
@@ -245,8 +245,10 @@ impl GameStateBranch for ForceStartStateBranch {
     fn process_state(&self,
                      _world: &World,
                      _referee: &Referee,
-                     _timer_opt: &mut Option<Instant>,
+                     timer_opt: &mut Option<Instant>,
                      _latest_data: &mut StateData) -> GameState {
+        // reset timer
+        *timer_opt = None;
         return GameState::Running(RunningState::Run);
     }
 }

--- a/crates/crabe_framework/src/data/state_handler/game_state_handler.rs
+++ b/crates/crabe_framework/src/data/state_handler/game_state_handler.rs
@@ -1,0 +1,385 @@
+use std::time::{Duration, Instant};
+use nalgebra::distance;
+use crate::data::referee::{Referee, RefereeCommand};
+use crate::data::referee::event::{BallLeftField, Event, GameEvent, GameEventType};
+use crate::data::state_handler::{GameStateBranch, StateData};
+use crate::data::world::game_state::{GameState, HaltedState, RunningState, StoppedState};
+use crate::data::world::{Ball, TeamColor, World};
+
+/// Checks whether the ball moved from its designated position
+/// It is based on the designated position sent by the referee, if there is one
+/// This function should only be called for states that require it
+/// (such as the FreeKick state, that implies the ball must be placed
+/// at a specific location to perform the free kick)
+fn ball_moved_from_designated_pos(referee: &Referee, ball_opt: &Option<Ball>) -> bool {
+    return if let Some(designated_pos) = referee.designated_position {
+        if let Some(ball) = &ball_opt {
+            distance(&ball.position.xy(), &designated_pos.xy()) >= 0.05
+        } else {
+            false
+        }
+    } else {
+        false
+    }
+}
+
+/// Definition of branches to follow for each
+/// referee command issued
+
+/// Halt command branch, often triggered manually, but sometimes
+/// in case of a foul, or other circumstances
+pub struct HaltStateBranch;
+
+impl GameStateBranch for HaltStateBranch {
+    fn process_state(&mut self,
+                     _world: &World,
+                     _referee: &Referee,
+                     _timer_opt: &mut Option<Instant>,
+                     _for_team: &TeamColor,
+                     _latest_data: &StateData) -> GameState {
+        return GameState::Halted(HaltedState::Halt);
+    }
+}
+
+pub struct TimeoutStateBranch;
+impl GameStateBranch for TimeoutStateBranch {
+    fn process_state(&mut self,
+                     _world: &World,
+                     _referee: &Referee,
+                     _timer_opt: &mut Option<Instant>,
+                     for_team: &TeamColor,
+                     _latest_data: &StateData) -> GameState {
+        // TODO: maybe send information about the timeout
+        return GameState::Halted(HaltedState::Timeout(*for_team));
+    }
+}
+
+/// Stop command branch, used when robots should slow down.
+/// It's a transition state used for most of the actions
+pub struct StopStateBranch;
+
+impl StopStateBranch {
+
+    /// When the ball leaves the playing field by touching a goal line,
+    /// determine whether this will result in a corner kick or a goal kick,
+    /// depending on the faulting team
+    ///
+    /// TODO: this assembly of logic looks fat, maybe it could be reduced
+    fn goal_or_corner_kick(&self, world: &World, data: &BallLeftField) -> StoppedState {
+        return if let Some(ball_last_location) = &data.location {
+            let color_team_positive_side = world.data.positive_half;
+            let faulting_team = data.by_team;
+            let our_team_color = world.team_color;
+
+            // our team is on x-positive side
+            if color_team_positive_side == our_team_color {
+                // ball positive side (our side)
+                if ball_last_location.x > 0. {
+                    if faulting_team == our_team_color {
+                        StoppedState::CornerKick(our_team_color.opposite())
+                    } else {
+                        StoppedState::GoalKick(our_team_color)
+                    }
+                }
+                // ball negative side (enemy side)
+                else {
+                    if faulting_team == our_team_color {
+                        StoppedState::GoalKick(our_team_color.opposite())
+                    } else {
+                        StoppedState::CornerKick(our_team_color)
+                    }
+                }
+            }
+            // our team is on x-negative side
+            else {
+                // ball positive side (enemy side)
+                if ball_last_location.x > 0. {
+                    if faulting_team == our_team_color {
+                        StoppedState::CornerKick(our_team_color.opposite())
+                    } else {
+                        StoppedState::GoalKick(our_team_color)
+                    }
+                }
+                // ball negative side (our side)
+                else {
+                    if faulting_team == our_team_color {
+                        StoppedState::CornerKick(our_team_color.opposite())
+                    } else {
+                        StoppedState::GoalKick(our_team_color)
+                    }
+                }
+            }
+        } else {
+            // If we don't know where the ball went out, don't try to guess and return a bland state
+            StoppedState::Stop
+        }
+    }
+}
+
+impl StopStateBranch {
+    /// Checks whether a goal has been scored
+    fn was_goal_scored(&self, world: &World, referee: &Referee, latest_data: &StateData) -> Option<TeamColor> {
+        let our_team_color = world.team_color;
+        return if referee.ally.score > latest_data.ally_score {
+            Some(our_team_color)
+        } else if referee.enemy.score > latest_data.enemy_score {
+            Some(our_team_color.opposite())
+        } else {
+            None
+        }
+    }
+}
+
+impl GameStateBranch for StopStateBranch {
+    fn process_state(&mut self,
+                     world: &World,
+                     referee: &Referee,
+                     _timer_opt: &mut Option<Instant>,
+                     for_team: &TeamColor,
+                     latest_data: &StateData) -> GameState {
+
+        // handle first kickoff of the match
+        if !latest_data.kicked_off_once { return GameState::Stopped(StoppedState::PrepareForGameStart); };
+
+        // determine the reason of this Stop command
+
+        // is it because a goal was scored ?
+        // Dev note : When a goal is scored, these are the transitions happening
+        //  -> Halt | Human referee validates goal
+        //  -> Stop | Scores are updated, bots must prepare for kickoff
+        // To simplify, we'll just say that we will be put in the PrepareKickoff state
+        // after a goal is scored, to allow our robots to prepare themselves in advance
+        // It is not against the rules to do so (I believe)
+        if let Some(scoring_team) = self.was_goal_scored(world, referee, latest_data) {
+            return GameState::Stopped(StoppedState::PrepareKickoff(scoring_team.opposite()));
+        }
+
+        // otherwise, it might be because of an event that occurred
+        // (ball out of field, double touch foul etc...)
+        if let Some(game_event) = referee.game_events.last() {
+            let stopped_state: StoppedState = match &game_event.event {
+                // Common occurrences in a match
+                Event::BallLeftFieldTouchLine(data) => StoppedState::BallLeftFieldTouchLine(data.by_team),
+                Event::BallLeftFieldGoalLine(data) => self.goal_or_corner_kick(world, data),
+                Event::AimlessKick(data) => StoppedState::AimlessKick(data.by_team),
+
+                // Stopping fouls
+                Event::AttackerTooCloseToDefenseArea(_) |
+                Event::DefenderInDefenseArea(_) |
+                Event::BoundaryCrossing(_) |
+                Event::KeeperHeldBall(_) |
+                Event::BotDribbledBallTooFar(_) |
+                Event::BotPushedBot(_) |
+                Event::BotHeldBallDeliberately(_) |
+                Event::BotTippedOver(_) => StoppedState::FoulStop,
+
+
+                // The game is not progressing
+                Event::NoProgressInGame(_) => StoppedState::NoProgressInGame,
+
+                // Non-Stopping Fouls that can be ignored (or that never happen during a Stop state)
+                // TODO: more events might need management, but I was running low on time to sort everything
+                // Event::AttackerTouchedBallInDefenseArea(_) => {}
+                // Event::BotKickedBallTooFast(_) => {}
+                // Event::BotCrashUnique(_) => {}
+                // Event::BotCrashDrawn(_) => {}
+                // Event::DefenderTooCloseToKickPoint(_) => {}
+                // Event::BotTooFastInStop(_) => {}
+                // Event::BotInterferedPlacement(_) => {}
+                // Event::PossibleGoal(_) => {}
+                // Event::Goal(_) => {}
+                // Event::InvalidGoal(_) => {}
+                // Event::AttackerDoubleTouchedBall(_) => {}
+                // Event::PlacementSucceeded(_) => {}
+                // Event::PenaltyKickFailed(_) => {}
+                // Event::PlacementFailed(_) => {}
+                // Event::MultipleCards(_) => {}
+                // Event::MultipleFouls(_) => {}
+                // Event::TooManyRobots(_) => {}
+                // Event::BotSubstitution(_) => {}
+                // Event::ChallengeFlag(_) => {}
+                // Event::EmergencyStop(_) => {}
+                // Event::UnsportingBehaviorMinor(_) => {}
+                // Event::UnsportingBehaviorMajor(_) => {}
+                // Event::DeprecatedEvent => {}
+                _ => StoppedState::Stop
+            };
+            return GameState::Stopped(stopped_state);
+        }
+
+
+        // Default behaviour is to return a bland stop state,
+        // in case of no recent event or first kickoff
+        return GameState::Stopped(StoppedState::Stop);
+    }
+}
+
+/// Issued when the operator forces the game to resume
+pub struct ForceStartStateBranch;
+
+impl GameStateBranch for ForceStartStateBranch {
+    fn process_state(&mut self,
+                     _world: &World,
+                     _referee: &Referee,
+                     _timer_opt: &mut Option<Instant>,
+                     _for_team: &TeamColor,
+                     _latest_data: &StateData) -> GameState {
+        return GameState::Running(RunningState::Run);
+    }
+}
+
+/// When the game resumes normally, this command is issued,
+/// As far as it has been tested (with the game controller),
+/// this command is called after a PrepareKickoff or PreparePenalty
+pub struct NormalStartStateBranch;
+
+impl GameStateBranch for NormalStartStateBranch {
+    fn process_state(&mut self,
+                     world: &World,
+                     referee: &Referee,
+                     timer_opt: &mut Option<Instant>,
+                     for_team: &TeamColor,
+                     latest_data: &StateData) -> GameState {
+        // Here is how the game starts (or resumes after a goal)
+        // -> Halt
+        // -> Stop | Robots place themselves on their side of field
+        // -> PrepareKickoff | Kickoff preparation starts (2 seconds)
+        // -> NormalStart | Kickoff lasts for 10 seconds
+        match latest_data.prev_ref_cmd {
+            RefereeCommand::PrepareKickoff(of_team) => {
+                // A kickoff ends in two ways
+
+                // -> The ball moved from its designated position (ball is now in play)
+                if ball_moved_from_designated_pos(referee, &world.ball) {
+                    *timer_opt = None;
+                    GameState::Running(RunningState::Run)
+                }
+                else if let Some(timer) = timer_opt {
+                    // -> 10 seconds have elapsed
+                    if timer.elapsed() > Duration::from_secs(10) {
+                        *timer_opt = None;
+                        GameState::Running(RunningState::Run)
+                    } else {
+                        // otherwise we're still doing a kickoff
+                        GameState::Running(RunningState::KickOff(of_team))
+                    }
+                } else {
+                    // if there's no timer defined,
+                    // the kickoff just started, retain a timer to update
+                    *timer_opt = Some(Instant::now());
+                    GameState::Running(RunningState::KickOff(of_team))
+                }
+            }
+
+            RefereeCommand::PreparePenalty(of_team) => {
+                // yes, it is very similar to how we handle PrepareKickoff above
+                // but penalties have their own particularities, which are not
+                // completely handled (whether it's failed or successful, for example)
+                // the following will be the minimum required, we can change it later
+                if ball_moved_from_designated_pos(referee, &world.ball) {
+                    *timer_opt = None;
+                    GameState::Running(RunningState::Run)
+                }
+                else if let Some(timer) = timer_opt {
+                    // -> 10 seconds have elapsed
+                    if timer.elapsed() > Duration::from_secs(10) {
+                        *timer_opt = None;
+                        GameState::Running(RunningState::Run)
+                    } else {
+                        // otherwise we're still doing a penalty
+                        GameState::Running(RunningState::Penalty(of_team))
+                    }
+                } else {
+                    // if there's no timer defined,
+                    // the penalty just started, retain a timer to update
+                    *timer_opt = Some(Instant::now());
+                    GameState::Running(RunningState::Penalty(of_team))
+                }
+            }
+            _ => GameState::Running(RunningState::Run)
+        }
+    }
+}
+
+/// This branch is used as a placeholder if there is a RefereeCommand
+/// that was not handled, or a deprecated command has been sent
+pub struct DeprecatedStateBranch;
+
+impl GameStateBranch for DeprecatedStateBranch {
+    fn process_state(&mut self,
+                     world: &World,
+                     _referee: &Referee,
+                     _timer_opt: &mut Option<Instant>,
+                     _for_team: &TeamColor,
+                     _latest_data: &StateData) -> GameState {
+        return world.data.ref_orders.state;
+    }
+}
+
+pub struct FreekickStateBranch;
+
+impl GameStateBranch for FreekickStateBranch {
+    fn process_state(&mut self,
+                     world: &World,
+                     referee: &Referee,
+                     timer_opt: &mut Option<Instant>,
+                     for_team: &TeamColor,
+                     _previous_state_data: &StateData) -> GameState {
+        // If the ball moved at least 0.05 meters from its designated position,
+        // the kicker bot is considered to have touched the ball, and the game can resume normally
+        if ball_moved_from_designated_pos(referee, &world.ball) {
+            *timer_opt = None;
+            return GameState::Running(RunningState::Run)
+        }
+        // otherwise, check if we are still in the freekick state
+        else if let Some(timer) = &timer_opt {
+            // If 10 seconds haven't passed
+            if timer.elapsed() < Duration::from_secs(10) {
+                // There is still some time for the team to perform the freekick
+                GameState::Running(RunningState::FreeKick(*for_team))
+            } else {
+                // Free kick time has ended, moving on to the next state
+                // it is required to update the state in this case, because the referee
+                // will not send a new command telling us we can resume normal play
+                *timer_opt = None;
+                GameState::Running(RunningState::Run)
+            }
+        } else {
+            // A freekick has just started, save a timer to measure the time
+            *timer_opt = Some(Instant::now());
+            GameState::Running(RunningState::FreeKick(*for_team))
+        }
+    }
+}
+
+/// This branch is called when the referee issues the "PrepareKickoff" command
+/// We actually set this state way earlier compared to the referee, because
+/// the mentioned command is sent to give us a 2 seconds preparation for our robots,
+/// even though we're already allowed to prepare ourselves
+pub struct PrepareKickoffStateBranch;
+
+impl GameStateBranch for PrepareKickoffStateBranch {
+    fn process_state(&mut self,
+                     _world: &World,
+                     _referee: &Referee,
+                     _timer_opt: &mut Option<Instant>,
+                     for_team: &TeamColor,
+                     _previous_state_data: &StateData) -> GameState {
+        GameState::Stopped(StoppedState::PrepareKickoff(*for_team))
+    }
+}
+
+pub struct PreparePenaltyStateBranch;
+
+impl GameStateBranch for PreparePenaltyStateBranch {
+    fn process_state(&mut self,
+                     _world: &World,
+                     _referee: &Referee,
+                     _timer_opt: &mut Option<Instant>,
+                     for_team: &TeamColor,
+                     _previous_state_data: &StateData) -> GameState {
+        //TODO: improve this branch, with more StoppedState penalty states
+        // to define precisely what we should be doing
+        GameState::Stopped(StoppedState::PreparePenalty(*for_team))
+    }
+}

--- a/crates/crabe_framework/src/data/state_handler/game_state_handler.rs
+++ b/crates/crabe_framework/src/data/state_handler/game_state_handler.rs
@@ -246,9 +246,11 @@ impl GameStateBranch for ForceStartStateBranch {
                      _world: &World,
                      _referee: &Referee,
                      timer_opt: &mut Option<Instant>,
-                     _latest_data: &mut StateData) -> GameState {
+                     latest_data: &mut StateData) -> GameState {
         // reset timer
         *timer_opt = None;
+        // implies that the first kick-off was issued already
+        latest_data.kicked_off_once = true;
         return GameState::Running(RunningState::Run);
     }
 }
@@ -281,7 +283,7 @@ impl GameStateBranch for NormalStartStateBranch {
                     *timer_opt = None;
                     GameState::Running(RunningState::Run)
                 }
-                else if let Some(timer) = timer_opt {
+                else if let Some(timer) = timer_opt { // todo: we could use referee.current_action_time_remaining instead
                     // -> 10 seconds have elapsed
                     if timer.elapsed() > Duration::from_secs(10) {
                         *timer_opt = None;

--- a/crates/crabe_framework/src/data/state_handler/game_state_handler.rs
+++ b/crates/crabe_framework/src/data/state_handler/game_state_handler.rs
@@ -4,7 +4,7 @@ use log::{error, warn};
 use nalgebra::{distance, Point2};
 use crate::data::referee::{Referee, RefereeCommand};
 use crate::data::referee::event::{BallLeftField, Event, GameEvent, GameEventType};
-use crate::data::state_handler::{GameStateBranch, StateData};
+use crate::data::state_handler::{GameStateBranch, GameStateData};
 use crate::data::world::game_state::{GameState, HaltedState, RunningState, StoppedState};
 use crate::data::world::{Ball, Team, TeamColor, World};
 
@@ -43,7 +43,7 @@ impl GameStateBranch for HaltStateBranch {
                      _world: &World,
                      _referee: &Referee,
                      time_based_refresh: &mut bool,
-                     _latest_data: &mut StateData) -> GameState {
+                     _latest_data: &mut GameStateData) -> GameState {
 
         *time_based_refresh = false;
         return GameState::Halted(HaltedState::Halt);
@@ -63,7 +63,7 @@ impl GameStateBranch for TimeoutStateBranch {
                      _world: &World,
                      _referee: &Referee,
                      _time_based_refresh: &mut bool,
-                     _latest_data: &mut StateData) -> GameState {
+                     _latest_data: &mut GameStateData) -> GameState {
         // TODO: maybe send information about the timeout
         GameState::Halted(HaltedState::Timeout(self.for_team))
     }
@@ -131,7 +131,7 @@ impl StopStateBranch {
     }
 
     /// Checks whether a goal has been scored
-    fn was_goal_scored(&self, world: &World, referee: &Referee, latest_data: &StateData) -> Option<TeamColor> {
+    fn was_goal_scored(&self, world: &World, referee: &Referee, latest_data: &GameStateData) -> Option<TeamColor> {
         let our_team_color = world.team_color;
         return if referee.ally.score > latest_data.ally_score {
             Some(our_team_color)
@@ -148,7 +148,7 @@ impl GameStateBranch for StopStateBranch {
                      world: &World,
                      referee: &Referee,
                      _time_based_refresh: &mut bool,
-                     latest_data: &mut StateData) -> GameState {
+                     latest_data: &mut GameStateData) -> GameState {
 
         // handle first kickoff of the match
         if !latest_data.kicked_off_once {
@@ -276,7 +276,7 @@ impl GameStateBranch for ForceStartStateBranch {
                      _world: &World,
                      _referee: &Referee,
                      time_based_refresh: &mut bool,
-                     latest_data: &mut StateData) -> GameState {
+                     latest_data: &mut GameStateData) -> GameState {
         *time_based_refresh = false;
         // implies that the first kick-off was issued already
         latest_data.kicked_off_once = true;
@@ -294,7 +294,7 @@ impl GameStateBranch for NormalStartStateBranch {
                      world: &World,
                      referee: &Referee,
                      time_based_refresh: &mut bool,
-                     latest_data: &mut StateData) -> GameState {
+                     latest_data: &mut GameStateData) -> GameState {
         // Here is how the game starts (or resumes after a goal)
         // -> Halt
         // -> Stop | Robots place themselves on their side of field
@@ -368,7 +368,7 @@ impl GameStateBranch for DeprecatedStateBranch {
                      world: &World,
                      _referee: &Referee,
                      _time_based_refresh: &mut bool,
-                     _latest_data: &mut StateData) -> GameState {
+                     _latest_data: &mut GameStateData) -> GameState {
         warn!("Deprecated state has been used");
         return world.data.ref_orders.state;
     }
@@ -387,7 +387,7 @@ impl GameStateBranch for FreekickStateBranch {
                      world: &World,
                      referee: &Referee,
                      time_based_refresh: &mut bool,
-                     latest_data: &mut StateData) -> GameState {
+                     latest_data: &mut GameStateData) -> GameState {
         // If the ball moved at least 0.05 meters from its designated position,
         // the kicker bot is considered to have touched the ball, and the game can resume normally
         // precondition: the last designated pos has been provided by the referee
@@ -434,7 +434,7 @@ impl GameStateBranch for PrepareKickoffStateBranch {
                      _world: &World,
                      _referee: &Referee,
                      _time_based_refresh: &mut bool,
-                     _latest_data: &mut StateData) -> GameState {
+                     _latest_data: &mut GameStateData) -> GameState {
         GameState::Stopped(StoppedState::PrepareKickoff(self.for_team))
     }
 }
@@ -452,7 +452,7 @@ impl GameStateBranch for BallPlacementStateBranch {
                      _world: &World,
                      _referee: &Referee,
                      _time_based_refresh: &mut bool,
-                     _latest_data: &mut StateData) -> GameState {
+                     _latest_data: &mut GameStateData) -> GameState {
 
         GameState::Stopped(StoppedState::BallPlacement(self.by_team))
     }
@@ -471,7 +471,7 @@ impl GameStateBranch for PreparePenaltyStateBranch {
                      _world: &World,
                      _referee: &Referee,
                      _time_based_refresh: &mut bool,
-                     _latest_data: &mut StateData) -> GameState {
+                     _latest_data: &mut GameStateData) -> GameState {
         //TODO: improve this branch, with more StoppedState penalty states
         // to define precisely what we should be doing
         GameState::Stopped(StoppedState::PreparePenalty(self.for_team))

--- a/crates/crabe_framework/src/data/world.rs
+++ b/crates/crabe_framework/src/data/world.rs
@@ -11,7 +11,9 @@ pub use self::ball::Ball;
 mod team;
 pub use self::team::{Team, TeamColor};
 
-mod game_data;
+pub mod game_data;
+pub mod game_state;
+
 pub use self::game_data::GameData;
 
 use crate::config::CommonConfig;

--- a/crates/crabe_framework/src/data/world/game_data.rs
+++ b/crates/crabe_framework/src/data/world/game_data.rs
@@ -1,4 +1,5 @@
 use crate::data::world::{Team, TeamColor};
+use crate::data::referee::referee_orders::RefereeOrders;
 use serde::Serialize;
 
 /// The `GameData` struct represents the state of the SSL game, including the teams and which team is on the positive half of the field.
@@ -11,6 +12,9 @@ pub struct GameData {
     pub enemy: Team,
     /// The color of the team that is on the positive half of the field.
     pub positive_half: TeamColor,
+    /// Orders issued by the referee for both teams,
+    /// such as the current game state, the maximum speed allowed...
+    pub ref_orders: RefereeOrders
 }
 
 impl GameData {
@@ -20,6 +24,7 @@ impl GameData {
             ally: Team::with_color(team_color),
             enemy: Team::with_color(team_color.opposite()),
             positive_half: team_color.opposite(),
+            ref_orders: RefereeOrders::default(),
         }
     }
 }

--- a/crates/crabe_framework/src/data/world/game_state.rs
+++ b/crates/crabe_framework/src/data/world/game_state.rs
@@ -80,6 +80,11 @@ pub enum StoppedState {
     /// dev note: we use this state directly after a goal is scored
     PrepareKickoff(TeamColor),
 
+    /// [Non-official]
+    /// The team `TeamColor` will perform a free kick and
+    /// must put its robots in position
+    PrepareFreekick(TeamColor),
+
     /// The team `TeamColor` must prepare for a penalty kick
     PreparePenalty(TeamColor),
 

--- a/crates/crabe_framework/src/data/world/game_state.rs
+++ b/crates/crabe_framework/src/data/world/game_state.rs
@@ -1,0 +1,53 @@
+use crate::data::world::TeamColor;
+use serde::Serialize;
+
+/// Defines the possible game states of the match
+#[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum GameState {
+    Halted(HaltedState),
+    Stopped(StoppedState),
+    Running(RunningState),
+}
+
+#[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum HaltedState {
+    /// The game hasn't started yet
+    GameNotStarted,
+    /// A halt command has been issued
+    Halt,
+    /// A team is having a timeout
+    Timeout,
+}
+
+#[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum StoppedState {
+    /// The team `TeamColor` is preparing to do their kickoff
+    PrepareKickoff(TeamColor),
+    PreparePenalty(TeamColor),
+    /// The team `TeamColor` is trying to place the ball automatically
+    /// without the help of a human to pursue the game
+    BallPlacement(TeamColor),
+    /// Generic stop command, issued when robots must slow down after
+    /// a foul, for example. Can be issued manually
+    Stop,
+}
+
+#[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum RunningState {
+    /// The team `TeamColor` is doing their kickoff
+    /// Everyone can move, but only `TeamColor` is allowed
+    /// to perform the first ball touch
+    KickOff(TeamColor),
+    /// The team `TeamColor` has a robot ready to score a penalty
+    /// towards the goalkeeper of the enemy team
+    Penalty(TeamColor),
+    /// The team `TeamColor` can freely kick the ball once
+    FreeKick(TeamColor),
+    /// Generic running command, when no special event has occurred
+    /// Can be issued manually
+    Run,
+}

--- a/crates/crabe_framework/src/data/world/game_state.rs
+++ b/crates/crabe_framework/src/data/world/game_state.rs
@@ -2,6 +2,20 @@ use crate::data::world::TeamColor;
 use serde::Serialize;
 
 /// Defines the possible game states of the match
+/// Some states are not associated with commands sent from the referee
+/// These states are marked with the [Non-official] tag
+///
+/// Some commands and events link to a similar state,
+/// for example some fouls lead to a Stop state.
+/// When states are regrouped together, they are marked
+/// by the [Collection] tag
+///
+/// The [Extension] tag means that there was more than one possibility for an
+/// event, and that we required to split it into multiple states
+/// For example, let's say the ball leaves the field by
+/// touching a goal line, and the ball was played on the side of Team A,
+/// the opponent being Team B. This event can lead to either a goal kick
+/// (if it is Team B's fault) or a corner kick (if it is Team A's fault)
 #[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum GameState {
@@ -13,23 +27,72 @@ pub enum GameState {
 #[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum HaltedState {
-    /// The game hasn't started yet
+    /// [Non-official] The game hasn't started yet
     GameNotStarted,
     /// A halt command has been issued
     Halt,
     /// A team is having a timeout
-    Timeout,
+    Timeout(TeamColor),
 }
 
+/// A list of the most common Stop states that may occur
+/// during a game. Note that some states are behind a collection
+/// FoulStop, because they occur more rarely (such as a bot tipping over)
+/// The most common ones have been taken out of the collection, like the
+/// ball leaves field events. This is designed to explicitly define what
+/// the strategies should focus on, and what they can safely "ignore"
+/// to play a full game properly.
+///
+/// This distinction is purely subjective, but also comes from experience
+/// TODO: the layout of the `TeamColor` values is weird
+///  sometimes, the TeamColor is the team responsible for the error
+///  sometimes it's the opposite. Which one is better ?
 #[derive(Serialize, Copy, Clone, Debug, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum StoppedState {
-    /// The team `TeamColor` is preparing to do their kickoff
+    /// [Non-official] Prepare to move to our side of the field
+    /// before the game starts. At this point, we don't know who
+    /// is going to perform the first kickoff
+    PrepareForGameStart,
+
+    /// The team `TeamColor` made the ball leave the field by touching a touch line,
+    /// (the longest horizontal lines)
+    /// that will lead to a free kick for the opposite team
+    BallLeftFieldTouchLine(TeamColor),
+
+    /// [Extension] The ball crossed a goal line, and led to a corner kick
+    /// that will be shot by team `TeamColor` (a bot will kick the ball)
+    CornerKick(TeamColor),
+
+    /// [Extension] The ball crossed a goal line, and will lead to a goal kick
+    /// that will be shot by team `TeamColor` (the goalkeeper will kick the ball)
+    GoalKick(TeamColor),
+
+    /// An aimless kick was fired by team `TeamColor`, meaning it was not directed towards
+    /// the goal posts, and went out of the field. The opposite team will obtain a free kick
+    AimlessKick(TeamColor),
+    //AimlessKick(crate::data::referee::event::AimlessKick), //TODO: wish I could've done this
+
+    /// The game is stalling and no one is making any progression
+    NoProgressInGame,
+
+    /// The team `TeamColor` is going to do their kickoff.
+    /// dev note: we use this state directly after a goal is scored
     PrepareKickoff(TeamColor),
+
+    /// The team `TeamColor` must prepare for a penalty kick
     PreparePenalty(TeamColor),
+
     /// The team `TeamColor` is trying to place the ball automatically
     /// without the help of a human to pursue the game
     BallPlacement(TeamColor),
+
+    /// [Collection] A foul has occurred and will lead to a new state in the next seconds
+    /// Refer to the latest event from the referee to get data about the foul
+    /// Is not used for every stopping foul, but rather for fouls that could
+    /// be ignored while still playing a proper game
+    FoulStop,
+
     /// Generic stop command, issued when robots must slow down after
     /// a foul, for example. Can be issued manually
     Stop,
@@ -42,11 +105,14 @@ pub enum RunningState {
     /// Everyone can move, but only `TeamColor` is allowed
     /// to perform the first ball touch
     KickOff(TeamColor),
+
     /// The team `TeamColor` has a robot ready to score a penalty
     /// towards the goalkeeper of the enemy team
     Penalty(TeamColor),
+
     /// The team `TeamColor` can freely kick the ball once
     FreeKick(TeamColor),
+
     /// Generic running command, when no special event has occurred
     /// Can be issued manually
     Run,

--- a/crates/crabe_framework/src/data/world/team.rs
+++ b/crates/crabe_framework/src/data/world/team.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// The `TeamColor` enum represents the color of a team in the SSL game, either blue or yellow.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, Eq, PartialEq, Hash)]
 #[serde(rename_all = "camelCase")]
 pub enum TeamColor {
     Blue,

--- a/crates/crabe_framework/src/data/world/team.rs
+++ b/crates/crabe_framework/src/data/world/team.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// The `TeamColor` enum represents the color of a team in the SSL game, either blue or yellow.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum TeamColor {
     Blue,

--- a/crates/crabe_io/src/pipeline/input.rs
+++ b/crates/crabe_io/src/pipeline/input.rs
@@ -8,9 +8,6 @@ use crabe_framework::data::output::FeedbackMap;
 
 #[derive(Args)]
 pub struct InputConfig {
-    #[arg(long)]
-    gc: bool,
-
     #[command(flatten)]
     #[command(next_help_heading = "Vision")]
     pub vision_cfg: VisionConfig,
@@ -36,7 +33,7 @@ impl InputPipeline {
             common_cfg,
         ))];
 
-        if input_cfg.gc {
+        if common_cfg.gc {
             tasks.push(Box::new(GameController::with_config(input_cfg.gc_cfg)));
         }
 


### PR DESCRIPTION
# Revamped game state machine
## Description
contains all the necessary code to handle the referee commands sent by the game controller, and thus to translate this into game states we can refer to when playing. I based myself on [rbc-last-match](https://github.com/NAMeC-team/CRAbE/tree/rbc-last-match) for the base code to use

the translated states do not completely stick to what is defined in the rulebook. instead, I took the opportunity to create, extend and regroup similar states together, to create a more comprehensive environment for the developers that need to refer to the current game state when choosing which strategy to employ to command the robots

## Translated data from the GC to use in a match
The new structure `RefereeOrders` is available and gets updated in the `world.data.ref_orders` field in the global `world` variable. It exposes the necessary data to use in the match, such as
- Current game state
- Latest game event 
- Speed limit
- Min distance to maintain from the ball
- The last designated position

Last item is used to tell where the ball must be placed for a freekick

## Internal changes

The same design as the previous state machine reader from 2023. I've designed it around a common trait that all branches must implement. Multiple structures have been added to manage the different possibilities.
There are more events handled compared to the previous version.



This PR still lacks a proper penalty state management. Because this never happened last year, it is considered to not be a priority compared to the tasks that must be done before RoboCup 2024.

## Side notes
i recommend reading the commits thoroughly, because I wrote up what the commits do inside
the commits are very big because splitting this into small parts would have made no sense (and would require extra time that I do not really have) 